### PR TITLE
町域が含まれていないときに市区町村に含まれる最初の町域がヒットしてしまっていた不具合を解消した。

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Change Log の形式は [Keep a Changelog](http://keepachangelog.com/) に従い
 
 ### Fixed
 
+- [#25](https://github.com/yamat47/japanese_address_parser/pull/25) 町域が含まれていないときに市区町村に含まれる最初の町域がヒットしてしまっていた不具合を解消した。([@yamat47](https://github.com/yamat47))
+
 ### Security
 
 ## [1.1.0] - 2022-01-07

--- a/lib/japanese_address_parser/address_parser.rb
+++ b/lib/japanese_address_parser/address_parser.rb
@@ -19,6 +19,9 @@ module JapaneseAddressParser
       return _build_address(full_address: full_address, prefecture: prefecture) if city.nil?
 
       town_and_after = city_and_after.delete_prefix(city.name)
+
+      return _build_address(full_address: full_address, prefecture: prefecture, city: city) if town_and_after.empty?
+
       normalized_town_and_after = ::JapaneseAddressParser::AddressParser::TownAndAfterNormalizer.call(town_and_after)
       town_and_after_pattern = ::JapaneseAddressParser::AddressParser::PatternCreator.call(normalized_town_and_after)
 

--- a/spec/japanese_address_parser_spec.rb
+++ b/spec/japanese_address_parser_spec.rb
@@ -6,6 +6,18 @@ require 'yaml'
   describe '.call' do
     subject(:parsed_address) { described_class.call(full_address) }
 
+    context '町域が含まれていないとき' do
+      let(:full_address) { '東京都北区' }
+
+      it '市区町村まで解析できる' do
+        expect(parsed_address).to(be_a(::JapaneseAddressParser::Models::Address))
+        expect(parsed_address.prefecture).to(be_a(::JapaneseAddressParser::Models::Prefecture))
+        expect(parsed_address.city).to(be_a(::JapaneseAddressParser::Models::City))
+        expect(parsed_address.town).to(be_nil)
+        expect(parsed_address.furigana).to(eq('トウキョウトキタク'))
+      end
+    end
+
     ::YAML.load_file('spec/addresses.yml').each do |address|
       context "#{address['full_address']}のとき" do
         let(:full_address) { address['full_address'] }


### PR DESCRIPTION
Closes #24 

---

プルリクエストを Ready にする前に、以下のチェック項目が満たされていることを確認してください。

- [x] イシューとプルリクエストが関連付けられている。
- [x] （ユーザーに伝えたい変更を加えたとき）CHANGELOG.md の Unreleased に内容が追記されている。
