### PR TITLE
住所の解析に失敗したときに例外を吐くモードと吐かないモードを使い分けられるようにした。

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Change Log の形式は [Keep a Changelog](http://keepachangelog.com/) に従い
 ## [Unreleased]
 ### Added
 
+- [#44](https://github.com/yamat47/japanese_address_parser/pull/44) 住所の解析に失敗したときに例外を吐くモードと吐かないモードを使い分けられるようにした。([@yamat47](https://github.com/yamat47))
+
 ### Changed
 
 - [#43](https://github.com/yamat47/japanese_address_parser/pull/43) 町丁目データを取得する処理の効率を上げた。([@yamat47](https://github.com/yamat47))

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ address.full_address #=> "東京都港区芝公園4-2-8"
 address.furigana #=> "トウキョウトミナトクシバコウエン 4"
 ```
 
+### 都道府県・市区町村・町域データの属性
 <details>
 <summary>都道府県データの属性</summary>
 
@@ -92,7 +93,16 @@ address.furigana #=> "トウキョウトミナトクシバコウエン 4"
 
 都道府県や市区町村、町域のそれぞれの属性の値は [geolonia/japanese-addresses](https://github.com/geolonia/japanese-addresses) が提供している CSV ファイルの値そのままです。
 
-何らかの理由で住所の解析に失敗したときは `JapaneseAddressParser::NormalizeError` を `raise` します。
+### `JapaneseAddressParser.call(address)`
+`address` の値を解析して、都道府県・市区町村・町域のデータを返します。
+
+なんらかの理由で住所の解析に失敗したときは `nil` を返します。
+
+### `JapaneseAddressParser.call!(address)`
+
+`address` の値を解析して、都道府県・市区町村・町域のデータを返します。
+
+なんらかの理由で住所の解析に失敗したときは `JapaneseAddressParser::NormalizeError` の例外を吐きます。
 
 ## 開発
 開発に必要なライブラリをインストールするには、このコマンドを実行してください：

--- a/lib/japanese_address_parser.rb
+++ b/lib/japanese_address_parser.rb
@@ -5,13 +5,24 @@ require_relative 'japanese_address_parser/address_parser'
 require_relative 'japanese_address_parser/version'
 
 module JapaneseAddressParser
-  module_function
-
   def call(full_address)
+    _call(full_address)
+  rescue ::JapaneseAddressParser::NormalizeError
+    nil
+  end
+
+  def call!(full_address)
+    _call(full_address)
+  end
+
+  def _call(full_address)
     normalized = ::JapaneseAddressParser::AddressNormalizer.call(full_address)
 
     # このライブラリで探索するのは町域まで。
     # それ以降のデータを使って探索するとデータと名前が一致しないことがあるので、町域までのデータを使う。
     ::JapaneseAddressParser::AddressParser.call("#{normalized['pref']}#{normalized['city']}#{normalized['town']}")
   end
+
+  module_function :call, :call!, :_call
+  private_class_method :_call
 end

--- a/spec/japanese_address_parser_spec.rb
+++ b/spec/japanese_address_parser_spec.rb
@@ -63,8 +63,74 @@ require 'yaml'
         allow(::JapaneseAddressParser::AddressNormalizer::NormalizeJapaneseAddressesSchmoozer).to(receive(:call).and_raise(::Schmooze::JavaScript::FetchError))
       end
 
+      specify 'nilを返すこと' do
+        expect(described_class.call('東京都渋谷区恵比寿1-1-1')).to(be_nil)
+      end
+    end
+  end
+
+  describe '.call!' do
+    context '町域が含まれていないとき' do
+      it '市区町村まで解析できる' do
+        parsed_address = described_class.call!('東京都北区')
+
+        expect(parsed_address).to(be_a(::JapaneseAddressParser::Models::Address))
+        expect(parsed_address.prefecture).to(be_a(::JapaneseAddressParser::Models::Prefecture))
+        expect(parsed_address.city).to(be_a(::JapaneseAddressParser::Models::City))
+        expect(parsed_address.town).to(be_nil)
+        expect(parsed_address.furigana).to(eq('トウキョウトキタク'))
+      end
+    end
+
+    ::YAML.load_file('spec/japanese_address_parser_spec/parsable_to_prefecture_addresses.yml').each do |address|
+      context "#{address['full_address']}のとき" do
+        it '都道府県まで解析できる' do
+          parsed_address = described_class.call!(address['full_address'])
+
+          expect(parsed_address).to(be_a(::JapaneseAddressParser::Models::Address))
+          expect(parsed_address.prefecture).to(be_a(::JapaneseAddressParser::Models::Prefecture))
+          expect(parsed_address.city).to(be_nil)
+          expect(parsed_address.town).to(be_nil)
+          expect(parsed_address.furigana).to(eq(address['furigana']))
+        end
+      end
+    end
+
+    ::YAML.load_file('spec/japanese_address_parser_spec/parsable_to_city_addresses.yml').each do |address|
+      context "#{address['full_address']}のとき" do
+        it '市区町村まで解析できる' do
+          parsed_address = described_class.call!(address['full_address'])
+
+          expect(parsed_address).to(be_a(::JapaneseAddressParser::Models::Address))
+          expect(parsed_address.prefecture).to(be_a(::JapaneseAddressParser::Models::Prefecture))
+          expect(parsed_address.city).to(be_a(::JapaneseAddressParser::Models::City))
+          expect(parsed_address.town).to(be_nil)
+          expect(parsed_address.furigana).to(eq(address['furigana']))
+        end
+      end
+    end
+
+    ::YAML.load_file('spec/japanese_address_parser_spec/addresses.yml').each do |address|
+      context "#{address['full_address']}のとき" do
+        it '町域まで解析できる' do
+          parsed_address = described_class.call!(address['full_address'])
+
+          expect(parsed_address).to(be_a(::JapaneseAddressParser::Models::Address))
+          expect(parsed_address.prefecture).to(be_a(::JapaneseAddressParser::Models::Prefecture))
+          expect(parsed_address.city).to(be_a(::JapaneseAddressParser::Models::City))
+          expect(parsed_address.town).to(be_a(::JapaneseAddressParser::Models::Town))
+          expect(parsed_address.furigana).to(eq(address['furigana']))
+        end
+      end
+    end
+
+    context 'Schmoozerが例外を吐いたとき' do
+      before do
+        allow(::JapaneseAddressParser::AddressNormalizer::NormalizeJapaneseAddressesSchmoozer).to(receive(:call).and_raise(::Schmooze::JavaScript::FetchError))
+      end
+
       specify '::JapaneseAddressParser::NormalizeErrorを吐くこと' do
-        expect { described_class.call('東京都渋谷区恵比寿1-1-1') }
+        expect { described_class.call!('東京都渋谷区恵比寿1-1-1') }
           .to(raise_error(::JapaneseAddressParser::NormalizeError))
       end
     end


### PR DESCRIPTION
Closes #42 

---

プルリクエストを Ready にする前に、以下のチェック項目が満たされていることを確認してください。

- [x] イシューとプルリクエストが関連付けられている。
- [x] （ユーザーに伝えたい変更を加えたとき）CHANGELOG.md の Unreleased に内容が追記されている。
