### PR TITLE
Dependabotがライブラリを更新するときに、それに依存しているソースコードも自動で更新されるようにした。

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
-name: Ruby
-
+name: CI
 on:
   push:
     branches:

--- a/.github/workflows/update_node_modules.yml
+++ b/.github/workflows/update_node_modules.yml
@@ -1,0 +1,22 @@
+name: Update node_modules
+on:
+  pull_request:
+    branches:
+      # /jsの中のnpmパッケージが更新されたプルリクエストに対してのみ実行する。
+      - 'dependabot/npm_and_yarn/js/**'
+
+jobs:
+  update_node_modules:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JavaScript
+      uses: actions/setup-node@v2
+    - name: Update node_modules
+      run: cd js && npm install
+    - name: Commit changes
+      uses: EndBug/add-and-commit@v9
+      with:
+        add: js/node_modules
+        default_author: github_actor
+        message: '[Automatic] Update node_modules.'

--- a/.github/workflows/update_parsed_csv.yml
+++ b/.github/workflows/update_parsed_csv.yml
@@ -1,0 +1,27 @@
+name: Update parsed csv
+on:
+  pull_request:
+    branches:
+      # /geolonia-japanese-addressesのサブモジュールが更新されたプルリクエストに対してのみ実行する。
+      - 'dependabot/submodules/geolonia-japanese-addresses**'
+
+jobs:
+  update_parsed_csv:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.1'
+        bundler-cache: true
+    - name: Update parsed csv
+      run: bundle exec rake japanese_address_parser:parse_csv
+    - name: Commit changes
+      uses: EndBug/add-and-commit@v9
+      with:
+        add: lib/japanese_address_parser/data
+        default_author: github_actor
+        message: '[Automatic] Update parsed csv.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Change Log の形式は [Keep a Changelog](http://keepachangelog.com/) に従い
 ### Added
 
 - [#61](https://github.com/yamat47/japanese_address_parser/pull/61) Dependabotを使ってsubmodulesやnpmライブラリが自動で更新される仕組みを作った。([@yamat47](https://github.com/yamat47))
+- [#64](https://github.com/yamat47/japanese_address_parser/pull/64) Dependabotがライブラリを更新するときに、それに依存しているソースコードも自動で更新されるようにした。([@yamat47](https://github.com/yamat47))
 
 ### Changed
 


### PR DESCRIPTION
依存関係の更新はDependabotに任せてしまう。
具体的には二つのファイル群を自動で更新する：

* 住所の正規化に使っているnpmのライブラリのソースコード（node_modules）
* 正規化された住所の一覧が載っているCSVファイル

References: #5, #60

---

プルリクエストを Ready にする前に、以下のチェック項目が満たされていることを確認してください。

- [x] イシューとプルリクエストが関連付けられている。
- [x] （ユーザーに伝えたい変更を加えたとき）CHANGELOG.md の Unreleased に内容が追記されている。
