### PR TITLE
READMEのCIステータスバッジがリンク切れになっていたのを直した。

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Change Log の形式は [Keep a Changelog](http://keepachangelog.com/) に従い
 
 ### Fixed
 
+- [#75](https://github.com/yamat47/japanese_address_parser/pull/75) READMEのCIステータスバッジがリンク切れになっていたのを直した。([@yamat47](https://github.com/yamat47))
+
 ### Security
 
 ## [3.0.3] - 2022-12-28

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![CI Status](https://github.com/yamat47/japanese_address_parser/actions/workflows/main.yml/badge.svg) [![Gem Version](https://badge.fury.io/rb/japanese_address_parser.svg)](https://badge.fury.io/rb/japanese_address_parser) [![Maintainability](https://api.codeclimate.com/v1/badges/e9b7d0622cf6cc4143c3/maintainability)](https://codeclimate.com/github/yamat47/japanese_address_parser/maintainability)
+![CI Status](https://github.com/yamat47/japanese_address_parser/actions/workflows/ci.yml/badge.svg) [![Gem Version](https://badge.fury.io/rb/japanese_address_parser.svg)](https://badge.fury.io/rb/japanese_address_parser) [![Maintainability](https://api.codeclimate.com/v1/badges/e9b7d0622cf6cc4143c3/maintainability)](https://codeclimate.com/github/yamat47/japanese_address_parser/maintainability)
 
 # JapaneseAddressParser
 JapaneseAddressParser は日本の住所をパースすることができる Ruby gem です。


### PR DESCRIPTION
CIのファイルの名前が変わっていたのが原因。
fix: https://github.com/yamat47/japanese_address_parser/issues/74

Closes #74 

---

プルリクエストを Ready にする前に、以下のチェック項目が満たされていることを確認してください。

- [x] イシューとプルリクエストが関連付けられている。
- [x] （ユーザーに伝えたい変更を加えたとき）CHANGELOG.md の Unreleased に内容が追記されている。
