### PR TITLE
`#full_address`が処理前の住所の一部のみを返すようになっていた不具合を解消した。

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,12 @@ Metrics/BlockLength:
 RSpec/ContextWording:
   Enabled: false
 
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
 # MITなのでファイルの著作権は記載しない。
 Style/Copyright:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Change Log の形式は [Keep a Changelog](http://keepachangelog.com/) に従い
 
 ### Removed
 
+- [#102](https://github.com/yamat47/japanese_address_parser/pull/102) #full_addressが処理前の住所の一部のみを返すようになっていた不具合を解消した。([@yamat47](https://github.com/yamat47))
+
 ### Fixed
 
 ### Security

--- a/lib/japanese_address_parser.rb
+++ b/lib/japanese_address_parser.rb
@@ -20,7 +20,7 @@ module JapaneseAddressParser
 
     # このライブラリで探索するのは町域まで。
     # それ以降のデータを使って探索するとデータと名前が一致しないことがあるので、町域までのデータを使う。
-    ::JapaneseAddressParser::AddressParser.call("#{normalized['pref']}#{normalized['city']}#{normalized['town']}")
+    ::JapaneseAddressParser::AddressParser.call(normalized: "#{normalized['pref']}#{normalized['city']}#{normalized['town']}", full_address: full_address)
   end
 
   module_function :call, :call!, :_call

--- a/lib/japanese_address_parser/address_parser.rb
+++ b/lib/japanese_address_parser/address_parser.rb
@@ -5,12 +5,12 @@ require_relative './models/prefecture'
 
 module JapaneseAddressParser
   module AddressParser
-    def call(full_address)
-      prefecture = ::JapaneseAddressParser::Models::Prefecture.all.find { |candidate| full_address.start_with?(candidate.name) }
+    def call(normalized:, full_address:)
+      prefecture = ::JapaneseAddressParser::Models::Prefecture.all.find { |candidate| normalized.start_with?(candidate.name) }
 
       return _build_address(full_address: full_address) if prefecture.nil?
 
-      city_and_after = full_address.delete_prefix(prefecture.name)
+      city_and_after = normalized.delete_prefix(prefecture.name)
       city = prefecture.cities.find { |candidate| city_and_after.start_with?(candidate.name) }
 
       return _build_address(full_address: full_address, prefecture: prefecture) if city.nil?

--- a/sig/japanese_address_parser.rbs
+++ b/sig/japanese_address_parser.rbs
@@ -20,7 +20,7 @@ module JapaneseAddressParser
   end
 
   module AddressParser
-    def self.call: (String full_address) -> Models::Address
+    def self.call: (normalized: String, full_address: String) -> Models::Address
   end
 
   module Models

--- a/spec/japanese_address_parser_spec.rb
+++ b/spec/japanese_address_parser_spec.rb
@@ -12,6 +12,7 @@ require_relative 'support/yaml_loader'
         expect(parsed_address.prefecture).to(be_a(::JapaneseAddressParser::Models::Prefecture))
         expect(parsed_address.city).to(be_a(::JapaneseAddressParser::Models::City))
         expect(parsed_address.town).to(be_nil)
+        expect(parsed_address.full_address).to(eq('東京都北区'))
         expect(parsed_address.furigana).to(eq('トウキョウトキタク'))
       end
     end
@@ -25,6 +26,7 @@ require_relative 'support/yaml_loader'
           expect(parsed_address.prefecture).to(be_a(::JapaneseAddressParser::Models::Prefecture))
           expect(parsed_address.city).to(be_nil)
           expect(parsed_address.town).to(be_nil)
+          expect(parsed_address.full_address).to(eq(address['full_address']))
           expect(parsed_address.furigana).to(eq(address['furigana']))
         end
       end
@@ -39,6 +41,7 @@ require_relative 'support/yaml_loader'
           expect(parsed_address.prefecture).to(be_a(::JapaneseAddressParser::Models::Prefecture))
           expect(parsed_address.city).to(be_a(::JapaneseAddressParser::Models::City))
           expect(parsed_address.town).to(be_nil)
+          expect(parsed_address.full_address).to(eq(address['full_address']))
           expect(parsed_address.furigana).to(eq(address['furigana']))
         end
       end
@@ -53,6 +56,7 @@ require_relative 'support/yaml_loader'
           expect(parsed_address.prefecture).to(be_a(::JapaneseAddressParser::Models::Prefecture))
           expect(parsed_address.city).to(be_a(::JapaneseAddressParser::Models::City))
           expect(parsed_address.town).to(be_a(::JapaneseAddressParser::Models::Town))
+          expect(parsed_address.full_address).to(eq(address['full_address']))
           expect(parsed_address.furigana).to(eq(address['furigana']))
         end
       end
@@ -78,6 +82,7 @@ require_relative 'support/yaml_loader'
         expect(parsed_address.prefecture).to(be_a(::JapaneseAddressParser::Models::Prefecture))
         expect(parsed_address.city).to(be_a(::JapaneseAddressParser::Models::City))
         expect(parsed_address.town).to(be_nil)
+        expect(parsed_address.full_address).to(eq('東京都北区'))
         expect(parsed_address.furigana).to(eq('トウキョウトキタク'))
       end
     end
@@ -91,6 +96,7 @@ require_relative 'support/yaml_loader'
           expect(parsed_address.prefecture).to(be_a(::JapaneseAddressParser::Models::Prefecture))
           expect(parsed_address.city).to(be_nil)
           expect(parsed_address.town).to(be_nil)
+          expect(parsed_address.full_address).to(eq(address['full_address']))
           expect(parsed_address.furigana).to(eq(address['furigana']))
         end
       end
@@ -105,6 +111,7 @@ require_relative 'support/yaml_loader'
           expect(parsed_address.prefecture).to(be_a(::JapaneseAddressParser::Models::Prefecture))
           expect(parsed_address.city).to(be_a(::JapaneseAddressParser::Models::City))
           expect(parsed_address.town).to(be_nil)
+          expect(parsed_address.full_address).to(eq(address['full_address']))
           expect(parsed_address.furigana).to(eq(address['furigana']))
         end
       end
@@ -119,6 +126,7 @@ require_relative 'support/yaml_loader'
           expect(parsed_address.prefecture).to(be_a(::JapaneseAddressParser::Models::Prefecture))
           expect(parsed_address.city).to(be_a(::JapaneseAddressParser::Models::City))
           expect(parsed_address.town).to(be_a(::JapaneseAddressParser::Models::Town))
+          expect(parsed_address.full_address).to(eq(address['full_address']))
           expect(parsed_address.furigana).to(eq(address['furigana']))
         end
       end


### PR DESCRIPTION
Closes #100 

---

プルリクエストを Ready にする前に、以下のチェック項目が満たされていることを確認してください。

- [x] イシューとプルリクエストが関連付けられている。
- [x] （ユーザーに伝えたい変更を加えたとき）CHANGELOG.md の Unreleased に内容が追記されている。
