### PR TITLE
Add csv to gemspec for new Ruby versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Change Log の形式は [Keep a Changelog](http://keepachangelog.com/) に従い
 ### Added
 - [#109](https://github.com/yamat47/japanese_address_parser/pull/109) READMEにDocker composeを利用した際の使い方を追記([@tossyi](https://github.com/tossyi))
 
+- Add csv to gemspec for new Ruby versions
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Change Log の形式は [Keep a Changelog](http://keepachangelog.com/) に従い
 ### Added
 - [#109](https://github.com/yamat47/japanese_address_parser/pull/109) READMEにDocker composeを利用した際の使い方を追記([@tossyi](https://github.com/tossyi))
 
-- Add csv to gemspec for new Ruby versions
+- [#108](https://github.com/yamat47/japanese_address_parser/pull/108) Add csv to gemspec for new Ruby versions ([@balvig](https://github.com/balvig))
 
 ### Changed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     japanese_address_parser (3.2.0)
+      csv
       schmooze
 
 GEM
@@ -14,6 +15,7 @@ GEM
       tzinfo (~> 2.0)
     ast (2.4.2)
     concurrent-ruby (1.2.2)
+    csv (3.3.2)
     diff-lcs (1.5.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)

--- a/japanese_address_parser.gemspec
+++ b/japanese_address_parser.gemspec
@@ -30,8 +30,8 @@ require_relative 'lib/japanese_address_parser/version'
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| ::File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency('schmooze')
   spec.add_dependency('csv')
+  spec.add_dependency('schmooze')
   spec.add_development_dependency('activesupport')
   spec.add_development_dependency('factory_bot')
   spec.add_development_dependency('rake')

--- a/japanese_address_parser.gemspec
+++ b/japanese_address_parser.gemspec
@@ -31,6 +31,7 @@ require_relative 'lib/japanese_address_parser/version'
   spec.require_paths = ['lib']
 
   spec.add_dependency('schmooze')
+  spec.add_dependency('csv')
   spec.add_development_dependency('activesupport')
   spec.add_development_dependency('factory_bot')
   spec.add_development_dependency('rake')


### PR DESCRIPTION
Ruby3.3で以下のエラーが表示されます：

```
warning: ruby/3.3.6/lib/ruby/3.3.0/csv.rb was loaded from the standard library, but will no longer
be part of the default gems starting from Ruby 3.4.0.
You can add csv to your Gemfile or gemspec to silence this warning.
Also please contact the author of japanese_address_parser-3.2.0 to request adding csv into its gemspec.
```

---

プルリクエストを Ready にする前に、以下のチェック項目が満たされていることを確認してください。

- [x] イシューとプルリクエストが関連付けられている。
- [x] （ユーザーに伝えたい変更を加えたとき）CHANGELOG.md の Unreleased に内容が追記されている。
