### PR TITLE
`normalize-japanese-addresses`の`addr`（町域以降の文字列）をサポートする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Change Log の形式は [Keep a Changelog](http://keepachangelog.com/) に従い
 
 ### Added
 
+- [#113](https://github.com/yamat47/japanese_address_parser/pull/113) `Address#addr`を追加して、町域以降の文字列を取得できるようにした。([@s-n-1-0](https://github.com/s-n-1-0))
+
 ### Changed
 
 ### Deprecated

--- a/lib/japanese_address_parser.rb
+++ b/lib/japanese_address_parser.rb
@@ -20,7 +20,7 @@ module JapaneseAddressParser
 
     # このライブラリで探索するのは町域まで。
     # それ以降のデータを使って探索するとデータと名前が一致しないことがあるので、町域までのデータを使う。
-    ::JapaneseAddressParser::AddressParser.call(normalized: "#{normalized['pref']}#{normalized['city']}#{normalized['town']}", full_address: full_address)
+    ::JapaneseAddressParser::AddressParser.call(normalized: "#{normalized['pref']}#{normalized['city']}#{normalized['town']}", full_address: full_address, remaining_addr: normalized['addr'])
   end
 
   module_function :call, :call!, :_call

--- a/lib/japanese_address_parser/address_parser.rb
+++ b/lib/japanese_address_parser/address_parser.rb
@@ -5,27 +5,27 @@ require_relative './models/prefecture'
 
 module JapaneseAddressParser
   module AddressParser
-    def call(normalized:, full_address:)
+    def call(normalized:, full_address:, remaining_addr:)
       prefecture = ::JapaneseAddressParser::Models::Prefecture.all.find { |candidate| normalized.start_with?(candidate.name) }
 
-      return _build_address(full_address: full_address) if prefecture.nil?
+      return _build_address(full_address: full_address, remaining_addr: remaining_addr) if prefecture.nil?
 
       city_and_after = normalized.delete_prefix(prefecture.name)
       city = prefecture.cities.find { |candidate| city_and_after.start_with?(candidate.name) }
 
-      return _build_address(full_address: full_address, prefecture: prefecture) if city.nil?
+      return _build_address(full_address: full_address, prefecture: prefecture, remaining_addr: remaining_addr) if city.nil?
 
       town_and_after = city_and_after.delete_prefix(city.name)
 
-      return _build_address(full_address: full_address, prefecture: prefecture, city: city) if town_and_after.empty?
+      return _build_address(full_address: full_address, prefecture: prefecture, city: city, remaining_addr: remaining_addr) if town_and_after.empty?
 
       town = city.towns.find { |candidate| town_and_after == candidate.name }
 
-      _build_address(full_address: full_address, prefecture: prefecture, city: city, town: town)
+      _build_address(full_address: full_address, prefecture: prefecture, city: city, town: town, remaining_addr: remaining_addr)
     end
 
-    def _build_address(full_address:, prefecture: nil, city: nil, town: nil)
-      ::JapaneseAddressParser::Models::Address.new(full_address: full_address, prefecture: prefecture, city: city, town: town)
+    def _build_address(full_address:, prefecture: nil, city: nil, town: nil, remaining_addr:)
+      ::JapaneseAddressParser::Models::Address.new(full_address: full_address, prefecture: prefecture, city: city, town: town, addr: remaining_addr)
     end
 
     module_function :call, :_build_address

--- a/lib/japanese_address_parser/models/address.rb
+++ b/lib/japanese_address_parser/models/address.rb
@@ -3,13 +3,14 @@
 module JapaneseAddressParser
   module Models
     class Address
-      attr_reader :full_address, :prefecture, :city, :town
+      attr_reader :full_address, :prefecture, :city, :town, :addr
 
-      def initialize(full_address:, prefecture:, city:, town:)
+      def initialize(full_address:, prefecture:, city:, town:, addr:)
         @full_address = full_address
         @prefecture = prefecture
         @city = city
         @town = town
+        @addr = addr
       end
 
       def furigana

--- a/sig/japanese_address_parser.rbs
+++ b/sig/japanese_address_parser.rbs
@@ -20,17 +20,18 @@ module JapaneseAddressParser
   end
 
   module AddressParser
-    def self.call: (normalized: String, full_address: String) -> Models::Address
+    def self.call: (normalized: String, full_address: String, remaining_addr: String) -> Models::Address
   end
 
   module Models
     class Address
-      def initialize: (full_address: String, prefecture: Models::Prefecture?, city: Models::City?, town: Models::Town?) -> void
+      def initialize: (full_address: String, prefecture: Models::Prefecture?, city: Models::City?, town: Models::Town?, addr: String) -> void
       def furigana: -> String
       attr_reader full_address: String
       attr_reader prefecture: Models::Prefecture?
       attr_reader city: Models::City?
       attr_reader town: Models::Town?
+      attr_reader addr: String
     end
 
     class Town

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -8,9 +8,10 @@ require_relative '../../lib/japanese_address_parser/models/address'
     city
     town
     full_address { "#{prefecture&.name}#{city&.name}#{town&.name}1-1" }
+    addr { '1-1' }
 
     initialize_with do
-      new(full_address: full_address, prefecture: prefecture, city: city, town: town)
+      new(full_address: full_address, prefecture: prefecture, city: city, town: town, addr: addr)
     end
   end
 end

--- a/spec/japanese_address_parser_spec.rb
+++ b/spec/japanese_address_parser_spec.rb
@@ -14,6 +14,15 @@ require_relative 'support/yaml_loader'
         expect(parsed_address.town).to(be_nil)
         expect(parsed_address.full_address).to(eq('東京都北区'))
         expect(parsed_address.furigana).to(eq('トウキョウトキタク'))
+        expect(parsed_address.addr).to(eq(''))
+      end
+    end
+
+    context '番地以降が含まれているとき' do
+      it 'addrを取得できる' do
+        parsed_address = described_class.call('東京都港区芝公園4-2-8')
+
+        expect(parsed_address.addr).to(eq('2-8'))
       end
     end
 
@@ -84,6 +93,15 @@ require_relative 'support/yaml_loader'
         expect(parsed_address.town).to(be_nil)
         expect(parsed_address.full_address).to(eq('東京都北区'))
         expect(parsed_address.furigana).to(eq('トウキョウトキタク'))
+        expect(parsed_address.addr).to(eq(''))
+      end
+    end
+
+    context '番地以降が含まれているとき' do
+      it 'addrを取得できる' do
+        parsed_address = described_class.call!('東京都港区芝公園4-2-8')
+
+        expect(parsed_address.addr).to(eq('2-8'))
       end
     end
 


### PR DESCRIPTION
Closes https://github.com/yamat47/japanese_address_parser/issues/114

---

プルリクエストを Ready にする前に、以下のチェック項目が満たされていることを確認してください。

- [x] イシューとプルリクエストが関連付けられている。
- [x] （ユーザーに伝えたい変更を加えたとき）CHANGELOG.md の Unreleased に内容が追記されている。
