### PR TITLE
feat(v4): M1 データモデル層 — SinglePrefecture / SingleCity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,6 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - name: Run RSpec
-      run: bundle exec rspec
+      # v4 リアーキの spec は専用ワークフロー ci_rearchitecture.yml で実行する。
+      # （Data.define は Ruby 3.2+ 必須で、この旧マトリクスの 2.7〜3.1 では読み込めない）
+      run: bundle exec rspec --exclude-pattern "v4/**/*_spec.rb"

--- a/.github/workflows/ci_rearchitecture.yml
+++ b/.github/workflows/ci_rearchitecture.yml
@@ -1,0 +1,50 @@
+name: CI (v4 rearchitecture)
+
+# v4.0.0 リアーキ（lib/japanese_address_parser/v4 配下）専用の CI。
+# 旧 schmooze 実装の ci.yml とは独立。Node 不要・Ruby 3.2+ 前提（Data.define）。
+on:
+  push:
+    branches:
+      - rearchitecture
+  pull_request:
+    paths:
+      - 'lib/japanese_address_parser/v4/**'
+      - 'spec/v4/**'
+      - 'sig/v4/**'
+      - '.github/workflows/ci_rearchitecture.yml'
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    name: Ruby 3.3 - v4 RuboCop & Steep
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3'
+        bundler-cache: true
+    - name: RuboCop check (v4)
+      run: bundle exec rubocop lib/japanese_address_parser/v4 spec/v4
+    - name: Steep check
+      run: bundle exec steep check
+
+  rspec:
+    runs-on: ubuntu-latest
+    name: Ruby ${{ matrix.ruby }} - v4 RSpec
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.4 は M9（gemspec / 依存バージョン更新）で追加する。
+        ruby:
+          - '3.2'
+          - '3.3'
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - name: Run RSpec (v4)
+      run: bundle exec rspec spec/v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,12 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Enabled: false
 
+# v4 リアーキの spec は隔離のため spec/v4 配下に置く（クラスの名前空間を
+# そのままパスに写すと spec/japanese_address_parser/v4/... となり隔離できない）。
+RSpec/FilePath:
+  Exclude:
+    - spec/v4/**/*_spec.rb
+
 # MITなのでファイルの著作権は記載しない。
 Style/Copyright:
   Enabled: false
@@ -38,6 +44,10 @@ Style/StringHashKeys:
 
     # ライブラリが返すハッシュのキーが文字列なので許容する。
     - spec/japanese_address_parser/address_normalizer_spec.rb
+
+    # 配信 API の JSON（文字列キー）を from_json に渡すため日本語/文字列キーのハッシュを許容する。
+    - spec/v4/data/single_city_spec.rb
+    - spec/v4/data/single_prefecture_spec.rb
 
 # elseがない場合にはcase文ではなくif文を許容する。
 Style/MissingElse:

--- a/docs/working_agreement.md
+++ b/docs/working_agreement.md
@@ -44,6 +44,16 @@
 - **中間リリースはしない**。`rearchitecture → main` の最終 PR で v4.0.0 を一括リリース。
 - コミットメッセージ末尾の Co-Authored-By 等、リポジトリの規約に従う。**コミット・プッシュはオーナーの指示があるときだけ**行う。
 
+### 2.1 新旧コードの物理的分離（M1〜M8 の暫定運用）
+
+旧 schmooze 実装と並存させる間、**v4 の新規コードはすべて `V4` 接頭辞配下に隔離**し、旧実装とファイル名・定数とも衝突させない。
+
+- コード: `lib/japanese_address_parser/v4/**`（名前空間 `JapaneseAddressParser::V4::...`、内部の `Data.define` は `::Data.define` と明示）
+- spec: `spec/v4/**`（fixture も `spec/v4/fixtures/` 配下）
+- RBS: `sig/v4/**`
+- **CI は別ワークフロー** `.github/workflows/ci_rearchitecture.yml`（Ruby 3.2/3.3、Node 不要）。旧 `ci.yml` の rspec マトリクス（2.7〜3.1 を含む）は `--exclude-pattern "v4/**/*_spec.rb"` で新 spec を除外する（`Data.define` は 3.2+ 必須のため）。
+- **M9 で旧実装を撤去した後、`v4/` を `lib/japanese_address_parser/` 直下へ昇格**して `V4` 接頭辞を外す（`docs/upstream_mapping.md` の最終パスに一致させる）。ワークフローもこの時に統合する。
+
 ---
 
 ## 3. 逐語移植のルール（fidelity）

--- a/lib/japanese_address_parser/v4/data/single_city.rb
+++ b/lib/japanese_address_parser/v4/data/single_city.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/japanese-addresses-v2/blob/bb4d000ae136d8b8b571ebccd39a772cc6afc67a/src/data.ts
+# Upstream: @geolonia/japanese-addresses-v2 v0.0.5 (data spec for @geolonia/normalize-japanese-addresses v3.1.3)
+
+module JapaneseAddressParser
+  module V4
+    module Data
+      # SingleCity — api/ja.json の cities 要素（政令市の場合は区で区切られる）。
+      # `::Data.define`（先頭 `::` は名前空間 JapaneseAddressParser::V4::Data 内で
+      # トップレベル定数 ::Data を指すために必須）。
+      SingleCity =
+        ::Data.define(:code, :county, :county_k, :county_r, :city, :city_k, :city_r, :ward, :ward_k, :ward_r, :point) do
+          # JS: cityName(city) => `${city.county || ''}${city.city}${city.ward || ''}`
+          # nil の補間は Ruby では空文字になるため `|| ''` 相当。
+          def city_name
+            "#{county}#{city}#{ward}"
+          end
+
+          # JSON（パース済み Hash・文字列キー）から VO を生成する Ruby 独自ヘルパ。
+          def self.from_json(hash)
+            new(
+              code: hash['code'],
+              county: hash['county'],
+              county_k: hash['county_k'],
+              county_r: hash['county_r'],
+              city: hash['city'],
+              city_k: hash['city_k'],
+              city_r: hash['city_r'],
+              ward: hash['ward'],
+              ward_k: hash['ward_k'],
+              ward_r: hash['ward_r'],
+              point: hash['point']
+            )
+          end
+        end
+      public_constant :SingleCity
+    end
+  end
+end

--- a/lib/japanese_address_parser/v4/data/single_prefecture.rb
+++ b/lib/japanese_address_parser/v4/data/single_prefecture.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/japanese-addresses-v2/blob/bb4d000ae136d8b8b571ebccd39a772cc6afc67a/src/data.ts
+# Upstream: @geolonia/japanese-addresses-v2 v0.0.5 (data spec for @geolonia/normalize-japanese-addresses v3.1.3)
+
+require_relative 'single_city'
+
+module JapaneseAddressParser
+  module V4
+    module Data
+      # SinglePrefecture — api/ja.json の data 要素（都道府県＋配下の市区町村一覧）。
+      SinglePrefecture =
+        ::Data.define(:code, :pref, :pref_k, :pref_r, :point, :cities) do
+          # JS: prefectureName(pref) => pref.pref
+          def prefecture_name
+            pref
+          end
+
+          # JSON（パース済み Hash・文字列キー）から VO を生成する Ruby 独自ヘルパ。
+          def self.from_json(hash)
+            cities = (hash['cities'] || []).map { |city| ::JapaneseAddressParser::V4::Data::SingleCity.from_json(city) }
+            new(code: hash['code'], pref: hash['pref'], pref_k: hash['pref_k'], pref_r: hash['pref_r'], point: hash['point'], cities: cities)
+          end
+        end
+      public_constant :SinglePrefecture
+    end
+  end
+end

--- a/sig/v4/data.rbs
+++ b/sig/v4/data.rbs
@@ -1,0 +1,44 @@
+# Interim signatures for the v4.0.0 data model layer (M1).
+# The full RBS overhaul happens in M9; these keep `steep check` green in the meantime.
+#
+# These are `Data.define` value objects, but the bundled RBS (rbs 2.6.0) predates the
+# core `Data` class, so they are declared as plain classes exposing the interface we use.
+
+module JapaneseAddressParser
+  module V4
+    module Data
+      class SingleCity
+        attr_reader code: Integer
+        attr_reader county: String?
+        attr_reader county_k: String?
+        attr_reader county_r: String?
+        attr_reader city: String
+        attr_reader city_k: String
+        attr_reader city_r: String
+        attr_reader ward: String?
+        attr_reader ward_k: String?
+        attr_reader ward_r: String?
+        attr_reader point: [Float, Float]
+
+        def self.new: (code: Integer, county: String?, county_k: String?, county_r: String?, city: String, city_k: String, city_r: String, ward: String?, ward_k: String?, ward_r: String?, point: [Float, Float]) -> instance
+        def self.from_json: (Hash[String, untyped] hash) -> SingleCity
+
+        def city_name: () -> String
+      end
+
+      class SinglePrefecture
+        attr_reader code: Integer
+        attr_reader pref: String
+        attr_reader pref_k: String
+        attr_reader pref_r: String
+        attr_reader point: [Float, Float]
+        attr_reader cities: Array[SingleCity]
+
+        def self.new: (code: Integer, pref: String, pref_k: String, pref_r: String, point: [Float, Float], cities: Array[SingleCity]) -> instance
+        def self.from_json: (Hash[String, untyped] hash) -> SinglePrefecture
+
+        def prefecture_name: () -> String
+      end
+    end
+  end
+end

--- a/spec/v4/data/single_city_spec.rb
+++ b/spec/v4/data/single_city_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/data/single_city'
+
+::RSpec.describe(::JapaneseAddressParser::V4::Data::SingleCity) do
+  describe '.from_json' do
+    context 'with a plain city (no county, no ward)' do
+      subject(:city) { described_class.from_json(hash) }
+
+      let(:hash) do
+        {
+          'code' => 12_025,
+          'city' => '函館市',
+          'city_k' => 'ハコダテシ',
+          'city_r' => 'Hakodate-shi',
+          'point' => [140.729108, 41.768712]
+        }
+      end
+
+      it 'maps present fields and leaves absent optionals nil' do
+        expect(city).to(
+          have_attributes(
+            code: 12_025,
+            city: '函館市',
+            city_k: 'ハコダテシ',
+            city_r: 'Hakodate-shi',
+            point: [140.729108, 41.768712],
+            county: nil,
+            county_k: nil,
+            county_r: nil,
+            ward: nil,
+            ward_k: nil,
+            ward_r: nil
+          )
+        )
+      end
+    end
+
+    context 'with a county city' do
+      subject(:city) do
+        described_class.from_json(
+          'code' => 13_030,
+          'county' => '石狩郡',
+          'county_k' => 'イシカリグン',
+          'county_r' => 'Ishikari-gun',
+          'city' => '当別町',
+          'city_k' => 'トウベツチョウ',
+          'city_r' => 'Tobetsu-cho',
+          'point' => [141.5170027, 43.22363701]
+        )
+      end
+
+      it 'retains the county fields' do
+        expect(city).to(have_attributes(county: '石狩郡', county_k: 'イシカリグン', county_r: 'Ishikari-gun'))
+      end
+    end
+  end
+
+  describe '#city_name' do
+    it 'returns just the city for a plain city' do
+      city = described_class.from_json('city' => '函館市')
+      expect(city.city_name).to(eq('函館市'))
+    end
+
+    it 'prepends the county (JS cityName: county + city + ward)' do
+      city = described_class.from_json('county' => '石狩郡', 'city' => '当別町')
+      expect(city.city_name).to(eq('石狩郡当別町'))
+    end
+
+    it 'appends the ward for an ordinance-designated city' do
+      city = described_class.from_json('city' => '札幌市', 'ward' => '中央区')
+      expect(city.city_name).to(eq('札幌市中央区'))
+    end
+  end
+end

--- a/spec/v4/data/single_prefecture_spec.rb
+++ b/spec/v4/data/single_prefecture_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'pathname'
+require 'japanese_address_parser/v4/data/single_prefecture'
+
+::RSpec.describe(::JapaneseAddressParser::V4::Data::SinglePrefecture) do
+  let(:fixture) do
+    path = ::Pathname.new(__dir__).join('../fixtures/data/ja_slice.json')
+    ::JSON.parse(path.read)
+  end
+  let(:hokkaido_hash) { fixture['data'].first }
+
+  describe '.from_json' do
+    subject(:prefecture) { described_class.from_json(hokkaido_hash) }
+
+    it 'maps the scalar fields' do
+      expect(prefecture).to(have_attributes(code: 10_006, pref: '北海道', pref_k: 'ホッカイドウ', pref_r: 'Hokkaido', point: [141.347906782, 43.0639406375]))
+    end
+
+    it 'converts each city into a SingleCity' do
+      expect(prefecture.cities).to(all(be_a(::JapaneseAddressParser::V4::Data::SingleCity)))
+      expect(prefecture.cities.map(&:city_name)).to(eq(%w[札幌市中央区 函館市 石狩郡当別町]))
+    end
+
+    it 'defaults cities to an empty array when absent' do
+      prefecture = described_class.from_json('code' => 1, 'pref' => '東京都')
+      expect(prefecture.cities).to(eq([]))
+    end
+  end
+
+  describe '#prefecture_name' do
+    it 'returns the pref field (JS prefectureName)' do
+      expect(described_class.from_json(hokkaido_hash).prefecture_name).to(eq('北海道'))
+    end
+  end
+end

--- a/spec/v4/fixtures/data/ja_slice.json
+++ b/spec/v4/fixtures/data/ja_slice.json
@@ -1,0 +1,41 @@
+{
+  "meta": { "updated": 1735102668 },
+  "data": [
+    {
+      "code": 10006,
+      "pref": "北海道",
+      "pref_k": "ホッカイドウ",
+      "pref_r": "Hokkaido",
+      "point": [141.347906782, 43.0639406375],
+      "cities": [
+        {
+          "code": 11011,
+          "city": "札幌市",
+          "city_k": "サッポロシ",
+          "city_r": "Sapporo-shi",
+          "ward": "中央区",
+          "ward_k": "チュウオウク",
+          "ward_r": "Chuo-ku",
+          "point": [141.35389, 43.061414]
+        },
+        {
+          "code": 12025,
+          "city": "函館市",
+          "city_k": "ハコダテシ",
+          "city_r": "Hakodate-shi",
+          "point": [140.729108, 41.768712]
+        },
+        {
+          "code": 13030,
+          "county": "石狩郡",
+          "county_k": "イシカリグン",
+          "county_r": "Ishikari-gun",
+          "city": "当別町",
+          "city_k": "トウベツチョウ",
+          "city_r": "Tobetsu-cho",
+          "point": [141.5170027, 43.22363701]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

v4.0.0 リアーキ（`docs/milestones.md` の **M1 データモデル層**）の第1PR。`@geolonia/japanese-addresses-v2` `src/data.ts`（v0.0.5, sha `bb4d000`）の `SinglePrefecture` / `SingleCity` 型とヘルパを Ruby に逐語移植する。

base は `rearchitecture`。

## 含まれるもの

- `lib/japanese_address_parser/v4/data/single_city.rb` — `Data::SingleCity` VO ＋ `#city_name`（JS `cityName`）＋ `.from_json`
- `lib/japanese_address_parser/v4/data/single_prefecture.rb` — `Data::SinglePrefecture` VO ＋ `#prefecture_name`（JS `prefectureName`）＋ `.from_json`（cities を再帰変換）
- `sig/v4/data.rbs` — interim RBS（全面刷新は M9）
- `spec/v4/data/*_spec.rb` ＋ `spec/v4/fixtures/data/ja_slice.json`（実 `ja.json` の北海道スライス：政令区/平/郡の3市）

## 新旧分離 & 専用 CI

旧 schmooze 実装と M9 まで並存させるため、新規コードを **`V4` 接頭辞配下に隔離**（旧実装とファイル名・定数とも非衝突）。M9 で旧実装撤去後に `lib/japanese_address_parser/` 直下へ昇格し接頭辞を外す。運用ルールは `docs/working_agreement.md` §2.1 に明文化。

- 新規 `.github/workflows/ci_rearchitecture.yml` — `v4/` 専用 CI（Ruby 3.2/3.3、Node 不要）
- 既存 `ci.yml` の rspec を `--exclude-pattern "v4/**/*_spec.rb"` に変更（`Data.define` は Ruby 3.2+ 必須で旧マトリクスの 2.7〜3.1 では読めないため）

## 忠実移植メモ

- `point` は `[lng, lat]` 順（data.ts の `LngLat` 通り）
- ヘルパは VO のインスタンスメソッド化（`city_name` = `"#{county}#{city}#{ward}"`、nil 補間が JS の `|| ''` と一致）
- `from_json`（Hash→VO）は Ruby 独自追加。各ファイル先頭の upstream URL コメントは型・ヘルパ定義元の data.ts を指す

## 検証（Ruby 3.3、すべて green）

- `bundle exec rspec spec/v4` → 9 examples, 0 failures
- `bundle exec rubocop`（全30ファイル）→ no offenses
- `bundle exec steep check` → No type error