### PR TITLE
feat(v4): complete M1 data model layer (SingleMachiAza/SingleRsdt/SingleChiban)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,12 @@ Metrics/BlockLength:
     - japanese_address_parser.gemspec
     - spec/**/*_spec.rb
 
+# v4 データ VO の from_json は JSON→VO の機械的フィールドマッピングで、
+# フィールド数が多い型（SingleMachiAza 等）では 1 行 1 フィールドの整形で行数が嵩む。
+Metrics/MethodLength:
+  Exclude:
+    - lib/japanese_address_parser/v4/data/*.rb
+
 # contextの記述を日本語で記述するのを許容する。
 RSpec/ContextWording:
   Enabled: false
@@ -48,6 +54,9 @@ Style/StringHashKeys:
     # 配信 API の JSON（文字列キー）を from_json に渡すため日本語/文字列キーのハッシュを許容する。
     - spec/v4/data/single_city_spec.rb
     - spec/v4/data/single_prefecture_spec.rb
+    - spec/v4/data/single_machi_aza_spec.rb
+    - spec/v4/data/single_rsdt_spec.rb
+    - spec/v4/data/single_chiban_spec.rb
 
 # elseがない場合にはcase文ではなくif文を許容する。
 Style/MissingElse:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-linux
 

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -6,7 +6,7 @@
 ## 進捗
 
 - [x] **M0** 設計確定（ドキュメント整備）
-- [ ] **M1** データモデル層（japanese-addresses-v2 型）
+- [x] **M1** データモデル層（japanese-addresses-v2 型）
 - [ ] **M2** ユーティリティ層
 - [ ] **M3** 設定 & データアクセス層（config / fetcher）
 - [ ] **M4** cacheRegexes（level 3 まで）

--- a/lib/japanese_address_parser/v4/data/single_chiban.rb
+++ b/lib/japanese_address_parser/v4/data/single_chiban.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/japanese-addresses-v2/blob/bb4d000ae136d8b8b571ebccd39a772cc6afc67a/src/data.ts
+# Upstream: @geolonia/japanese-addresses-v2 v0.0.5 (data spec for @geolonia/normalize-japanese-addresses v3.1.3)
+
+module JapaneseAddressParser
+  module V4
+    module Data
+      # SingleChiban — 地番（地番1・地番2・地番3）。M8 で CSV 行から生成する。
+      SingleChiban =
+        ::Data.define(:prc_num1, :prc_num2, :prc_num3, :point) do
+          # JS: chibanToString(chiban) => [prc_num1, prc_num2, prc_num3].filter(Boolean).join('-')
+          # JS の filter(Boolean) は falsy（nil・空文字）を除外する。Ruby では空文字は truthy なので
+          # compact だけでは不十分。nil と空文字の両方を除外して忠実に再現する。
+          def chiban_to_string
+            [prc_num1, prc_num2, prc_num3]
+              .reject { |value| value.nil? || value == '' }
+              .join('-')
+          end
+
+          # JSON（パース済み Hash・文字列キー）から VO を生成する Ruby 独自ヘルパ。
+          def self.from_json(hash)
+            new(prc_num1: hash['prc_num1'], prc_num2: hash['prc_num2'], prc_num3: hash['prc_num3'], point: hash['point'])
+          end
+        end
+      public_constant :SingleChiban
+    end
+  end
+end

--- a/lib/japanese_address_parser/v4/data/single_machi_aza.rb
+++ b/lib/japanese_address_parser/v4/data/single_machi_aza.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/japanese-addresses-v2/blob/bb4d000ae136d8b8b571ebccd39a772cc6afc67a/src/data.ts
+# Upstream: @geolonia/japanese-addresses-v2 v0.0.5 (data spec for @geolonia/normalize-japanese-addresses v3.1.3)
+
+module JapaneseAddressParser
+  module V4
+    module Data
+      # SingleMachiAza — api/ja/{都道府県名}/{市区町村名}.json の data 要素（町字）。
+      # `rsdt` は値が存在するとき必ず `true`（住居表示住所データの存在フラグ）。
+      # `csv_ranges` は level 8 で住居表示/地番 CSV の該当バイト範囲を引くために保持する。
+      SingleMachiAza =
+        ::Data.define(:machiaza_id, :oaza_cho, :oaza_cho_k, :oaza_cho_r, :chome, :chome_n, :koaza, :koaza_k, :koaza_r, :rsdt, :point, :csv_ranges) do
+          # JS: machiAzaName(machiAza) => `${oaza_cho || ''}${chome || ''}${koaza || ''}`
+          # nil の補間は Ruby では空文字になるため `|| ''` 相当。
+          def machi_aza_name
+            "#{oaza_cho}#{chome}#{koaza}"
+          end
+
+          # JSON（パース済み Hash・文字列キー）から VO を生成する Ruby 独自ヘルパ。
+          # csv_ranges は `{ "住居表示" => { "start" => Integer, "length" => Integer }, "地番" => {...} }`
+          # の構造をそのまま保持する（M8 で消費する）。
+          def self.from_json(hash)
+            new(
+              machiaza_id: hash['machiaza_id'],
+              oaza_cho: hash['oaza_cho'],
+              oaza_cho_k: hash['oaza_cho_k'],
+              oaza_cho_r: hash['oaza_cho_r'],
+              chome: hash['chome'],
+              chome_n: hash['chome_n'],
+              koaza: hash['koaza'],
+              koaza_k: hash['koaza_k'],
+              koaza_r: hash['koaza_r'],
+              rsdt: hash['rsdt'],
+              point: hash['point'],
+              csv_ranges: hash['csv_ranges']
+            )
+          end
+        end
+      public_constant :SingleMachiAza
+    end
+  end
+end

--- a/lib/japanese_address_parser/v4/data/single_rsdt.rb
+++ b/lib/japanese_address_parser/v4/data/single_rsdt.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/japanese-addresses-v2/blob/bb4d000ae136d8b8b571ebccd39a772cc6afc67a/src/data.ts
+# Upstream: @geolonia/japanese-addresses-v2 v0.0.5 (data spec for @geolonia/normalize-japanese-addresses v3.1.3)
+
+module JapaneseAddressParser
+  module V4
+    module Data
+      # SingleRsdt — 住居表示住所（街区符号・住居番号・住居番号2）。M8 で CSV 行から生成する。
+      SingleRsdt =
+        ::Data.define(:blk_num, :rsdt_num, :rsdt_num2, :point) do
+          # JS: rsdtToString(rsdt) => [blk_num, rsdt_num, rsdt_num2].filter(Boolean).join('-')
+          # JS の filter(Boolean) は falsy（nil・空文字）を除外する。Ruby では空文字は truthy なので
+          # compact だけでは不十分。nil と空文字の両方を除外して忠実に再現する。
+          def rsdt_to_string
+            [blk_num, rsdt_num, rsdt_num2]
+              .reject { |value| value.nil? || value == '' }
+              .join('-')
+          end
+
+          # JSON（パース済み Hash・文字列キー）から VO を生成する Ruby 独自ヘルパ。
+          def self.from_json(hash)
+            new(blk_num: hash['blk_num'], rsdt_num: hash['rsdt_num'], rsdt_num2: hash['rsdt_num2'], point: hash['point'])
+          end
+        end
+      public_constant :SingleRsdt
+    end
+  end
+end

--- a/sig/v4/data.rbs
+++ b/sig/v4/data.rbs
@@ -39,6 +39,50 @@ module JapaneseAddressParser
 
         def prefecture_name: () -> String
       end
+
+      class SingleMachiAza
+        attr_reader machiaza_id: String
+        attr_reader oaza_cho: String?
+        attr_reader oaza_cho_k: String?
+        attr_reader oaza_cho_r: String?
+        attr_reader chome: String?
+        attr_reader chome_n: Integer?
+        attr_reader koaza: String?
+        attr_reader koaza_k: String?
+        attr_reader koaza_r: String?
+        attr_reader rsdt: true?
+        attr_reader point: [Float, Float]?
+        attr_reader csv_ranges: Hash[String, Hash[String, Integer]]?
+
+        def self.new: (machiaza_id: String, oaza_cho: String?, oaza_cho_k: String?, oaza_cho_r: String?, chome: String?, chome_n: Integer?, koaza: String?, koaza_k: String?, koaza_r: String?, rsdt: true?, point: [Float, Float]?, csv_ranges: Hash[String, Hash[String, Integer]]?) -> instance
+        def self.from_json: (Hash[String, untyped] hash) -> SingleMachiAza
+
+        def machi_aza_name: () -> String
+      end
+
+      class SingleRsdt
+        attr_reader blk_num: String?
+        attr_reader rsdt_num: String
+        attr_reader rsdt_num2: String?
+        attr_reader point: [Float, Float]?
+
+        def self.new: (blk_num: String?, rsdt_num: String, rsdt_num2: String?, point: [Float, Float]?) -> instance
+        def self.from_json: (Hash[String, untyped] hash) -> SingleRsdt
+
+        def rsdt_to_string: () -> String
+      end
+
+      class SingleChiban
+        attr_reader prc_num1: String
+        attr_reader prc_num2: String?
+        attr_reader prc_num3: String?
+        attr_reader point: [Float, Float]?
+
+        def self.new: (prc_num1: String, prc_num2: String?, prc_num3: String?, point: [Float, Float]?) -> instance
+        def self.from_json: (Hash[String, untyped] hash) -> SingleChiban
+
+        def chiban_to_string: () -> String
+      end
     end
   end
 end

--- a/spec/v4/data/single_chiban_spec.rb
+++ b/spec/v4/data/single_chiban_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/data/single_chiban'
+
+::RSpec.describe(::JapaneseAddressParser::V4::Data::SingleChiban) do
+  describe '.from_json' do
+    it 'maps present fields and leaves absent optionals nil' do
+      chiban = described_class.from_json('prc_num1' => '1', 'point' => [139.6967, 35.6586])
+      expect(chiban).to(have_attributes(prc_num1: '1', prc_num2: nil, prc_num3: nil, point: [139.6967, 35.6586]))
+    end
+
+    it 'retains the second and third parcel numbers' do
+      chiban = described_class.from_json('prc_num1' => '1', 'prc_num2' => '2', 'prc_num3' => '3')
+      expect(chiban).to(have_attributes(prc_num1: '1', prc_num2: '2', prc_num3: '3'))
+    end
+  end
+
+  describe '#chiban_to_string' do
+    it 'joins the three parcel numbers with "-"' do
+      chiban = described_class.new(prc_num1: '1', prc_num2: '2', prc_num3: '3', point: nil)
+      expect(chiban.chiban_to_string).to(eq('1-2-3'))
+    end
+
+    it 'drops nil parts (JS filter(Boolean))' do
+      chiban = described_class.new(prc_num1: '1', prc_num2: nil, prc_num3: nil, point: nil)
+      expect(chiban.chiban_to_string).to(eq('1'))
+    end
+
+    # JS の filter(Boolean) は空文字も除外する。Ruby では "" は truthy なので compact では
+    # 落ちず、忠実移植のために明示的に除外している（upstream_mapping.md §2 の compact 案との差異）。
+    it 'drops empty-string parts as JS filter(Boolean) does (not merely nil)' do
+      chiban = described_class.new(prc_num1: '1', prc_num2: '', prc_num3: '3', point: nil)
+      expect(chiban.chiban_to_string).to(eq('1-3'))
+    end
+  end
+end

--- a/spec/v4/data/single_machi_aza_spec.rb
+++ b/spec/v4/data/single_machi_aza_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'pathname'
+require 'japanese_address_parser/v4/data/single_machi_aza'
+
+::RSpec.describe(::JapaneseAddressParser::V4::Data::SingleMachiAza) do
+  let(:fixture) do
+    path = ::Pathname.new(__dir__).join('../fixtures/data/machi_aza_slice.json')
+    ::JSON.parse(path.read)
+  end
+  let(:entries) { fixture['data'] }
+  # 0: 神宮前一丁目 (oaza+chome, rsdt, point, csv_ranges 両方)
+  # 1: 旭川清澄町 (oaza only, rsdt, point, csv_ranges 地番のみ)
+  # 2: 新屋町字後田 (oaza+koaza, point なし, csv_ranges 地番のみ)
+  # 3: クネソエ (koaza only, point あり, csv_ranges/rsdt なし)
+
+  describe '.from_json' do
+    subject(:machi_aza) { described_class.from_json(entries[0]) }
+
+    it 'maps the scalar fields including the integer chome_n' do
+      expect(machi_aza).to(have_attributes(machiaza_id: '0001001', oaza_cho: '神宮前', oaza_cho_k: 'ジングウマエ', oaza_cho_r: 'Jingumae', chome: '一丁目', chome_n: 1, rsdt: true, point: [139.705302, 35.671552]))
+    end
+
+    it 'preserves csv_ranges verbatim (both 住居表示 and 地番) for level 8' do
+      expect(machi_aza.csv_ranges).to(eq('地番' => { 'start' => 50_000, 'length' => 14_823 }, '住居表示' => { 'start' => 50_000, 'length' => 18_985 }))
+    end
+
+    it 'leaves absent optional fields nil' do
+      machi_aza = described_class.from_json(entries[3])
+      expect(machi_aza).to(have_attributes(oaza_cho: nil, oaza_cho_k: nil, chome: nil, chome_n: nil, koaza: 'クネソエ', rsdt: nil, csv_ranges: nil))
+    end
+
+    it 'keeps a csv_ranges that only carries 地番' do
+      machi_aza = described_class.from_json(entries[1])
+      expect(machi_aza.csv_ranges).to(eq('地番' => { 'start' => 100_000, 'length' => 3191 }))
+    end
+  end
+
+  describe '#machi_aza_name' do
+    it 'joins oaza_cho and chome (JS machiAzaName: oaza_cho + chome + koaza)' do
+      expect(described_class.from_json(entries[0]).machi_aza_name).to(eq('神宮前一丁目'))
+    end
+
+    it 'returns just the oaza_cho when there is no chome or koaza' do
+      expect(described_class.from_json(entries[1]).machi_aza_name).to(eq('旭川清澄町'))
+    end
+
+    it 'appends the koaza after the oaza_cho' do
+      expect(described_class.from_json(entries[2]).machi_aza_name).to(eq('新屋町字後田'))
+    end
+
+    it 'returns just the koaza when there is no oaza_cho' do
+      expect(described_class.from_json(entries[3]).machi_aza_name).to(eq('クネソエ'))
+    end
+  end
+end

--- a/spec/v4/data/single_rsdt_spec.rb
+++ b/spec/v4/data/single_rsdt_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/data/single_rsdt'
+
+::RSpec.describe(::JapaneseAddressParser::V4::Data::SingleRsdt) do
+  describe '.from_json' do
+    it 'maps present fields and leaves absent optionals nil' do
+      rsdt = described_class.from_json('rsdt_num' => '8', 'point' => [139.6967, 35.6586])
+      expect(rsdt).to(have_attributes(blk_num: nil, rsdt_num: '8', rsdt_num2: nil, point: [139.6967, 35.6586]))
+    end
+
+    it 'retains the block number and second residence number' do
+      rsdt = described_class.from_json('blk_num' => '10', 'rsdt_num' => '8', 'rsdt_num2' => '2')
+      expect(rsdt).to(have_attributes(blk_num: '10', rsdt_num: '8', rsdt_num2: '2'))
+    end
+  end
+
+  describe '#rsdt_to_string' do
+    it 'joins block number, residence number and second residence number with "-"' do
+      rsdt = described_class.new(blk_num: '10', rsdt_num: '8', rsdt_num2: '2', point: nil)
+      expect(rsdt.rsdt_to_string).to(eq('10-8-2'))
+    end
+
+    it 'drops nil parts (JS filter(Boolean))' do
+      rsdt = described_class.new(blk_num: nil, rsdt_num: '8', rsdt_num2: nil, point: nil)
+      expect(rsdt.rsdt_to_string).to(eq('8'))
+    end
+
+    # JS の filter(Boolean) は空文字も除外する。Ruby では "" は truthy なので compact では
+    # 落ちず、忠実移植のために明示的に除外している（upstream_mapping.md §2 の compact 案との差異）。
+    it 'drops empty-string parts as JS filter(Boolean) does (not merely nil)' do
+      rsdt = described_class.new(blk_num: '', rsdt_num: '8', rsdt_num2: '', point: nil)
+      expect(rsdt.rsdt_to_string).to(eq('8'))
+    end
+  end
+end

--- a/spec/v4/fixtures/data/machi_aza_slice.json
+++ b/spec/v4/fixtures/data/machi_aza_slice.json
@@ -1,0 +1,47 @@
+{
+  "meta": { "updated": 1735102670 },
+  "data": [
+    {
+      "machiaza_id": "0001001",
+      "oaza_cho": "神宮前",
+      "oaza_cho_k": "ジングウマエ",
+      "oaza_cho_r": "Jingumae",
+      "chome": "一丁目",
+      "chome_n": 1,
+      "rsdt": true,
+      "point": [139.705302, 35.671552],
+      "csv_ranges": {
+        "地番": { "start": 50000, "length": 14823 },
+        "住居表示": { "start": 50000, "length": 18985 }
+      }
+    },
+    {
+      "machiaza_id": "0001000",
+      "oaza_cho": "旭川清澄町",
+      "oaza_cho_k": "アサヒカワキヨスミマチ",
+      "oaza_cho_r": "Asahikawa Kiyosumimachi",
+      "rsdt": true,
+      "point": [140.128123, 39.743039],
+      "csv_ranges": {
+        "地番": { "start": 100000, "length": 3191 }
+      }
+    },
+    {
+      "machiaza_id": "0027101",
+      "oaza_cho": "新屋町",
+      "oaza_cho_k": "アラヤマチ",
+      "oaza_cho_r": "Arayamachi",
+      "koaza": "字後田",
+      "koaza_k": "アザウシロダ",
+      "csv_ranges": {
+        "地番": { "start": 330670, "length": 138 }
+      }
+    },
+    {
+      "machiaza_id": "0000101",
+      "koaza": "クネソエ",
+      "koaza_k": "クネソエ",
+      "point": [140.238453, 39.520472]
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

M1（データモデル層）の残り 3 型を `@geolonia/japanese-addresses-v2` `src/data.ts`（sha `bb4d000…`）から逐語移植し、**M1 を完了**する。先行 PR #115（`SinglePrefecture` / `SingleCity`）の続き。

base: `rearchitecture`

## 追加した型・ヘルパ

| 型 | ヘルパ | 備考 |
| --- | --- | --- |
| `SingleMachiAza` | `machi_aza_name`（大字＋丁目＋小字） | `csv_ranges`（住居表示/地番のバイト範囲）を**そのまま保持** — level 8（M8）で使用。`chome_n:Integer`・`rsdt:true` も保持 |
| `SingleRsdt` | `rsdt_to_string` | `[blk_num, rsdt_num, rsdt_num2]` を `-` 連結 |
| `SingleChiban` | `chiban_to_string` | `[prc_num1, prc_num2, prc_num3]` を `-` 連結 |

すべて `::Data.define` の immutable VO。`from_json`（配信 API の文字列キー Hash → VO）を備える。

## 忠実移植メモ（JS↔Ruby 差異）

- `rsdtToString` / `chibanToString` の JS は `.filter(Boolean)` で **nil だけでなく空文字も除外**する。Ruby では `""` は truthy なので `.compact` では落ちない。忠実再現のため `reject { |v| v.nil? || v == '' }` で実装し、**空文字除外の差異を spec に固定**した（`docs/upstream_mapping.md` §2 の `.compact` 案との差を spec 内コメントに明記）。

## その他の変更

- `sig/v4/data.rbs`: 3 型の interim RBS 追記（`csv_ranges: Hash[String, Hash[String, Integer]]?`、`rsdt: true?` 等）。
- `.rubocop.yml`:
  - 新 spec 3 件を `Style/StringHashKeys` 除外に追加（既存パターン踏襲）。
  - `Metrics/MethodLength` を `lib/japanese_address_parser/v4/data/*.rb` で除外。`EnabledByDefault: true` が `Layout/MultilineMethodArgumentLineBreaks`（1 引数 = 1 行）を強制するため、フィールド数の多い `SingleMachiAza#from_json` がデフォルト上限を超えるため。
- `docs/milestones.md`: M1 にチェック。
- `spec/v4/fixtures/data/machi_aza_slice.json`: 実 API データ抜粋（神宮前一丁目 / 旭川清澄町 / 新屋町字後田 / クネソエ）で 4 パターン網羅。

## 検証（Ruby 3.3.6）

- `bundle exec rspec spec/v4` → 27 examples, 0 failures
- `bundle exec rubocop`（全 36 ファイル）→ no offenses
- `bundle exec steep check` → No type error