### PR TITLE
feat(v4): add zen2han utility (M2)

### DIFF
--- a/lib/japanese_address_parser/v4/zen2han.rb
+++ b/lib/japanese_address_parser/v4/zen2han.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/lib/zen2han.ts
+# Upstream: @geolonia/normalize-japanese-addresses v3.1.3
+
+module JapaneseAddressParser
+  module V4
+    # 全角の英数字（Ａ-Ｚ・ａ-ｚ・０-９）を半角へ変換する。
+    module Zen2han
+      module_function
+
+      # JS:
+      #   str.replace(/[Ａ-Ｚａ-ｚ０-９]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xfee0))
+      # 全角英数字のコードポイントは半角より 0xFEE0 大きいので、その差を引いて半角へ落とす。
+      # 文字クラスは上流のリテラル範囲をそのまま移植する。
+      def call(str)
+        str.gsub(/[Ａ-Ｚａ-ｚ０-９]/) { |s| (s.ord - 0xFEE0).chr(::Encoding::UTF_8) }
+      end
+    end
+    public_constant :Zen2han
+  end
+end

--- a/sig/v4/zen2han.rbs
+++ b/sig/v4/zen2han.rbs
@@ -1,0 +1,10 @@
+# Interim signature for the v4.0.0 utility layer (M2).
+# The full RBS overhaul happens in M9; this keeps `steep check` green in the meantime.
+
+module JapaneseAddressParser
+  module V4
+    module Zen2han
+      def self.call: (String str) -> String
+    end
+  end
+end

--- a/spec/v4/zen2han_spec.rb
+++ b/spec/v4/zen2han_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/zen2han'
+
+::RSpec.describe(::JapaneseAddressParser::V4::Zen2han) do
+  describe '.call' do
+    it 'converts full-width uppercase letters to half-width' do
+      expect(described_class.call('ＡＢＣＸＹＺ')).to(eq('ABCXYZ'))
+    end
+
+    it 'converts full-width lowercase letters to half-width' do
+      expect(described_class.call('ａｂｃｘｙｚ')).to(eq('abcxyz'))
+    end
+
+    it 'converts full-width digits to half-width' do
+      expect(described_class.call('０１２３４５６７８９')).to(eq('0123456789'))
+    end
+
+    it 'converts the boundary characters of each range' do
+      expect(described_class.call('ＡＺａｚ０９')).to(eq('AZaz09'))
+    end
+
+    it 'converts only full-width alnum and leaves other characters untouched' do
+      expect(described_class.call('東京都Ａ１丁目')).to(eq('東京都A1丁目'))
+    end
+
+    it 'leaves a string without full-width alnum unchanged' do
+      expect(described_class.call('東京都渋谷区')).to(eq('東京都渋谷区'))
+    end
+
+    it 'returns an empty string for an empty input' do
+      expect(described_class.call('')).to(eq(''))
+    end
+  end
+end


### PR DESCRIPTION
## 概要

M2（ユーティリティ層）の最初の1ファイル。`src/lib/zen2han.ts` を逐語移植する。

- 移植元: [`src/lib/zen2han.ts`](https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/lib/zen2han.ts)（`@geolonia/normalize-japanese-addresses` v3.1.3）
- 全角英数字（`Ａ-Ｚ` / `ａ-ｚ` / `０-９`）を `−0xFEE0` で半角へ変換する。
- 文字クラスは上流のリテラル範囲をそのまま移植（working_agreement §3）。
- API 形状は `JapaneseAddressParser::V4::Zen2han.call(str)`（M2 共通方針: `.call`）。

## 変更

- `lib/japanese_address_parser/v4/zen2han.rb`
- `spec/v4/zen2han_spec.rb`（各範囲・境界文字・混在/日本語素通し・空文字）
- `sig/v4/zen2han.rbs`（M2 暫定シグネチャ、最終刷新は M9）

## 検証

| チェック | 結果 |
| --- | --- |
| `bundle exec rspec spec/v4/zen2han_spec.rb` | 7 examples, 0 failures |
| `bundle exec rubocop lib/japanese_address_parser/v4/zen2han.rb spec/v4/zen2han_spec.rb` | no offenses |
| `bundle exec steep check` | No type error |

## メモ

- base は `rearchitecture`。
- 参照: `docs/milestones.md` M2 / `docs/upstream_mapping.md` §1。