### PR TITLE
feat(v4): add kan2num utility for M2

### DIFF
--- a/lib/japanese_address_parser/v4/kan2num.rb
+++ b/lib/japanese_address_parser/v4/kan2num.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/lib/kan2num.ts
+# Upstream: @geolonia/normalize-japanese-addresses v3.1.3
+
+require 'japanese_address_parser/v4/japanese_numeral'
+
+module JapaneseAddressParser
+  module V4
+    # 文字列中の漢数字を算用数字へ置換する。
+    module Kan2num
+      module_function
+
+      # JS:
+      #   const kanjiNumbers = findKanjiNumbers(string)
+      #   for (...) { try { string = string.replace(kanjiNumbers[i], kanji2number(kanjiNumbers[i])) } catch { /* ignore */ } }
+      #
+      # 逐語移植上の要点:
+      #   - JS の String.prototype.replace(searchString, ...) は最初の 1 件のみ置換するので
+      #     Ruby は gsub ではなく sub を使う。
+      #   - kanji2number は TypeError を投げうる。JS の try/catch に合わせて rescue で握り潰す。
+      #     置換値は数値なので to_s で文字列化する。
+      def call(string)
+        kanji_numbers = JapaneseNumeral.find_kanji_numbers(string)
+        kanji_numbers.each do |kanji_number|
+          string = string.sub(kanji_number, JapaneseNumeral.kanji2number(kanji_number).to_s)
+        rescue ::StandardError
+          # ignore
+        end
+
+        string
+      end
+    end
+    public_constant :Kan2num
+  end
+end

--- a/sig/v4/kan2num.rbs
+++ b/sig/v4/kan2num.rbs
@@ -1,0 +1,10 @@
+# Interim signature for the v4.0.0 utility layer (M2).
+# The full RBS overhaul happens in M9.
+
+module JapaneseAddressParser
+  module V4
+    module Kan2num
+      def self.call: (String string) -> String
+    end
+  end
+end

--- a/spec/v4/kan2num_spec.rb
+++ b/spec/v4/kan2num_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/kan2num'
+
+::RSpec.describe(::JapaneseAddressParser::V4::Kan2num) do
+  describe '.call' do
+    it 'converts a single kanji numeral to an arabic numeral' do
+      expect(described_class.call('三丁目')).to(eq('3丁目'))
+    end
+
+    it 'converts multiple kanji numerals in one string' do
+      expect(described_class.call('一丁目十一番')).to(eq('1丁目11番'))
+    end
+
+    # JS の String.prototype.replace(searchString, ...) は最初の 1 件のみ置換する。
+    # gsub で実装すると先に '一' を全置換してしまい '十一' が壊れる（'1丁目十1番'）。
+    # sub での移植が正しいことを固定するケース。
+    it 'replaces only the first occurrence per found numeral (sub, not gsub)' do
+      expect(described_class.call('一丁目十一番')).to(eq('1丁目11番'))
+      expect(described_class.call('一丁目十一番')).not_to(eq('1丁目十1番'))
+    end
+
+    it 'leaves a string without kanji numerals unchanged' do
+      expect(described_class.call('東京都')).to(eq('東京都'))
+    end
+
+    it 'leaves full-width alphabets (non kanji numerals) unchanged' do
+      expect(described_class.call('ＡＢＣ')).to(eq('ＡＢＣ'))
+    end
+
+    # 上流挙動の忠実移植: kan2num は文脈を見ないため '千代田' の '千' も数値化する。
+    # 「改善しない」(working_agreement §3-2) を固定するケース。
+    it 'faithfully converts kanji numerals even inside place names (upstream behaviour)' do
+      expect(described_class.call('千代田区')).to(eq('1000代田区'))
+    end
+
+    # JS の try/catch に対応する rescue の検証。
+    # kanji2number('万一') は TypeError を投げるので、そのトークンは置換されず元のまま残る。
+    it 'ignores tokens that raise in kanji2number and keeps them as-is' do
+      expect(described_class.call('万一')).to(eq('万一'))
+    end
+
+    it 'keeps processing remaining tokens after a raising token is ignored' do
+      expect(described_class.call('万一の三丁目')).to(eq('万一の3丁目'))
+    end
+  end
+end


### PR DESCRIPTION
## What

M2（ユーティリティ層）の `kan2num` を逐語移植する。文字列中の漢数字を `find_kanji_numbers` で拾い、各々を `kanji2number` で算用数字へ置換する薄いラッパ。

移植元: [`src/lib/kan2num.ts`](https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/lib/kan2num.ts)（@geolonia/normalize-japanese-addresses v3.1.3）。

## 忠実移植の要点（specで固定）

- **`String#sub`（最初の1件のみ）** — JS の `String.prototype.replace(searchString, …)` は最初の1件のみ置換する。`gsub` だと `一丁目十一番` で先に `一` を全置換して `十一` が壊れる（`1丁目十1番`）。正しくは `1丁目11番`。`not_to` で固定。
- **`rescue ::StandardError`（JSの`try/catch`）** — `kanji2number` は `TypeError` を投げうる。`万一 → 万一`（据え置き）、`万一の三丁目 → 万一の3丁目`（例外トークンを飛ばして処理継続）。
- **上流忠実** — 文脈非依存なので `千代田区 → 1000代田区`（「改善しない」working_agreement §3-2）。

## 検証

- `rspec spec/v4/kan2num_spec.rb` — 8 examples, 0 failures
- `rubocop` — no offenses
- `steep check` — No type error
- `/simplify` — 4観点すべて clean（変更なし）

## マイルストーン

M2（ユーティリティ層）の3ユニット目。`zen2han` ✅ / `japanese_numeral` ✅ に続く。次は `dictionaries/jis_dai2`。