### PR TITLE
feat(v4): add dict to_regex_pattern utility for M2

### DIFF
--- a/lib/japanese_address_parser/v4/dict.rb
+++ b/lib/japanese_address_parser/v4/dict.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/lib/dict.ts
+# Upstream: @geolonia/normalize-japanese-addresses v3.1.3
+
+require 'japanese_address_parser/v4/dictionaries/convert'
+
+module JapaneseAddressParser
+  module V4
+    # 住所文字列を表記ゆれを吸収する正規表現パターン文字列へ変換する。
+    module Dict
+      module_function
+
+      # JS: toRegexPattern(string) — replace チェーンの順序をそのまま移植する。
+      # 「なるべく文字数が多いものほど上にすること」という上流コメント順を保持する。
+      # 置換文字列に $（JS 特殊）も \\（Ruby gsub 特殊）も含まれないため literal 置換になる。
+      def to_regex_pattern(string)
+        str = string
+              .gsub(/三栄町|四谷三栄町/, '(三栄町|四谷三栄町)')
+              .gsub(/鬮野川|くじ野川|くじの川/, '(鬮野川|くじ野川|くじの川)')
+              .gsub(/柿碕町|柿さき町/, '(柿碕町|柿さき町)')
+              .gsub(/通り|とおり/, '(通り|とおり)')
+              .gsub(/埠頭|ふ頭/, '(埠頭|ふ頭)')
+              .gsub(/番町|番丁/, '(番町|番丁)')
+              .gsub(/大冝|大宜/, '(大冝|大宜)')
+              .gsub(/穝|さい/, '(穝|さい)')
+              .gsub(/杁|えぶり/, '(杁|えぶり)')
+              .gsub(/薭|稗|ひえ|ヒエ/, '(薭|稗|ひえ|ヒエ)')
+              .gsub(/[之ノの]/, '[之ノの]')
+              .gsub(/[ヶケが]/, '[ヶケが]')
+              .gsub(/[ヵカか力]/, '[ヵカか力]')
+              .gsub(/[ッツっつ]/, '[ッツっつ]')
+              .gsub(/[ニ二]/, '[ニ二]')
+              .gsub(/[ハ八]/, '[ハ八]')
+              .gsub(/塚|塚/, '(塚|塚)')
+              .gsub(/釜|竈/, '(釜|竈)')
+              .gsub(/條|条/, '(條|条)')
+              .gsub(/狛|拍/, '(狛|拍)')
+              .gsub(/藪|薮/, '(藪|薮)')
+              .gsub(/渕|淵/, '(渕|淵)')
+              .gsub(/エ|ヱ|え/, '(エ|ヱ|え)')
+              .gsub(/曾|曽/, '(曾|曽)')
+              .gsub(/舟|船/, '(舟|船)')
+              .gsub(/莵|菟/, '(莵|菟)')
+              .gsub(/市|巿/, '(市|巿)')
+              .gsub(/崎|﨑/, '(崎|﨑)')
+
+        Dictionaries::Convert.call(str)
+      end
+    end
+    public_constant :Dict
+  end
+end

--- a/sig/v4/dict.rbs
+++ b/sig/v4/dict.rbs
@@ -1,0 +1,10 @@
+# Interim signature for the v4.0.0 utility layer (M2).
+# The full RBS overhaul happens in M9.
+
+module JapaneseAddressParser
+  module V4
+    module Dict
+      def self.to_regex_pattern: (String string) -> String
+    end
+  end
+end

--- a/spec/v4/dict_spec.rb
+++ b/spec/v4/dict_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/dict'
+
+::RSpec.describe(::JapaneseAddressParser::V4::Dict) do
+  describe '.to_regex_pattern' do
+    it 'expands a spelling-variant alternation in both directions' do
+      expect(described_class.to_regex_pattern('通り')).to(eq('(通り|とおり)'))
+      expect(described_class.to_regex_pattern('とおり')).to(eq('(通り|とおり)'))
+    end
+
+    it 'expands a kanji/kana alternation' do
+      expect(described_class.to_regex_pattern('番町')).to(eq('(番町|番丁)'))
+      expect(described_class.to_regex_pattern('番丁')).to(eq('(番町|番丁)'))
+    end
+
+    it 'replaces each member of a character class with the class itself' do
+      expect(described_class.to_regex_pattern('の')).to(eq('[之ノの]'))
+      expect(described_class.to_regex_pattern('之')).to(eq('[之ノの]'))
+      expect(described_class.to_regex_pattern('ノ')).to(eq('[之ノの]'))
+    end
+
+    it 'rewrites a character class inside a longer string' do
+      expect(described_class.to_regex_pattern('ヶ丘')).to(eq('[ヶケが]丘'))
+    end
+
+    # 見た目が同じでもコードポイントが異なるペアを厳密に保持する（上流 TS から生成）。
+    # 各 expect の直前コメントに対応コードポイントを明記する。
+    it 'preserves look-alike but distinct code points' do
+      # 塚 U+585A vs 塚 U+FA10
+      expect(described_class.to_regex_pattern('塚')).to(eq('(塚|塚)'))
+      # 崎 U+5D0E vs 﨑 U+FA11
+      expect(described_class.to_regex_pattern('崎')).to(eq('(崎|﨑)'))
+      expect(described_class.to_regex_pattern('﨑')).to(eq('(崎|﨑)'))
+      # 市 U+5E02 vs 巿 U+5DFF
+      expect(described_class.to_regex_pattern('市')).to(eq('(市|巿)'))
+    end
+
+    # チェーンの後段 gsub が前段の出力をさらに書き換える（順序依存）挙動を逐語再現する。
+    # '薭|稗|ひえ|ヒエ' → '(薭|稗|ひえ|ヒエ)' の後に 'エ|ヱ|え' 置換が内側の え/エ を展開する。
+    it 'applies later replacements to the output of earlier ones (chain order matters)' do
+      expect(described_class.to_regex_pattern('薭')).to(eq('(薭|稗|ひ(エ|ヱ|え)|ヒ(エ|ヱ|え))'))
+      expect(described_class.to_regex_pattern('ヒエ')).to(eq('(薭|稗|ひ(エ|ヱ|え)|ヒ(エ|ヱ|え))'))
+    end
+
+    # 末尾の Dictionaries::Convert により、辞書の旧/新字体も両方マッチパターンへ展開される。
+    it 'runs the dictionary convert step at the end' do
+      # 区 は jisDai2 の dst（區 => 区）なので convert が展開する
+      expect(described_class.to_regex_pattern('区')).to(eq('(區|区)'))
+      # チェーンで括られた後、内側の 栄（榮 => 栄 の dst）も convert で展開される
+      expect(described_class.to_regex_pattern('三栄町')).to(eq('(三(榮|栄)町|四谷三(榮|栄)町)'))
+    end
+
+    it 'leaves a string with no matching rules unchanged' do
+      expect(described_class.to_regex_pattern('東京都')).to(eq('東京都'))
+    end
+  end
+end


### PR DESCRIPTION
## What

M2（ユーティリティ層）の `dict`（`to_regex_pattern`）を逐語移植する。住所文字列を表記ゆれ吸収用の正規表現パターン文字列へ変換する。28段の `.replace` チェーン＋末尾で `Dictionaries::Convert`（先行PR #120）。

移植元: [`src/lib/dict.ts`](https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/lib/dict.ts)（@geolonia/normalize-japanese-addresses v3.1.3）。

## 忠実移植の要点（specで固定）

- **28段チェーンを順序込みで逐語コピー** — 置換文字列に `$`（JS特殊）も `\`（Ruby特殊）も無く literal 置換。パターンは単純な交替・1文字クラスのみで Onigmo↔V8 差異なし（global-match補正不要）。
- **チェーン順序依存** — `薭 → (薭|稗|ひ(エ|ヱ|え)|ヒ(エ|ヱ|え))`（後段の `エ|ヱ|え` 置換が前段出力の内側を展開）。
- **末尾 convert 連携** — `区 → (區|区)`、`三栄町 → (三(榮|栄)町|四谷三(榮|栄)町)`。
- **別コードポイント保持** — `塚`(U+585A/U+FA10)、`市`(U+5E02/U+5DFF)、`崎`(U+5D0E/U+FA11) を上流TS生成で厳密コピー。

## 検証

- `rspec spec/v4/dict_spec.rb` — 8 examples, 0 failures
- `rubocop` — no offenses
- `steep check` — No type error
- `/simplify` — 4観点 clean

## マイルストーン

M2 5ユニット目。`zen2han`✅ / `japanese_numeral`✅ / `kan2num`✅ / `dictionaries`✅ に続く。残りは `patch_addr` → `normalize_helpers` → `utils`。