### PR TITLE
feat(v4): add patch_addr utility for M2

### DIFF
--- a/lib/japanese_address_parser/v4/patch_addr.rb
+++ b/lib/japanese_address_parser/v4/patch_addr.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/lib/patchAddr.ts
+# Upstream: @geolonia/normalize-japanese-addresses v3.1.3
+
+module JapaneseAddressParser
+  module V4
+    # 特定の町について番地表記のゆれを補正する 3 パッチを適用する。
+    module PatchAddr
+      # JS の addrPatches。pattern は上流では '^字?家[6六]' のように `^` 始端アンカーを使う。
+      # JS の `^`（m フラグ無し）は「文字列先頭」を指すが、Ruby の `^` は「行頭」を指すため、
+      # 文字列先頭の意味を保つには `\A` へ翻訳する必要がある（working_agreement §3-4 の
+      # JS↔Onigmo 差異。挙動の忠実性を優先し `^` → `\A` と訳す）。
+      ADDR_PATCHES = [
+        { pref: '香川県', city: '仲多度郡まんのう町', town: '勝浦', pattern: '\A字?家[6六]', result: '家六' },
+        { pref: '愛知県', city: 'あま市', town: '西今宿', pattern: '\A字?梶村[1一]', result: '梶村一' },
+        { pref: '香川県', city: '丸亀市', town: '原田町', pattern: '\A字?東三分[1一]', result: '東三分一' }
+      ].freeze
+
+      private_constant :ADDR_PATCHES
+
+      module_function
+
+      # JS: patchAddr(prefName, cityName, townName, addr)
+      # JS は param を直接変更しないよう `let _addr = addr` を使うが、Ruby では仮引数
+      # addr を再代入して同じ動作にする（_addr 接頭辞は Lint/UnderscorePrefixedVariableName）。
+      def call(pref_name, city_name, town_name, addr)
+        ADDR_PATCHES.each do |patch|
+          next unless patch[:pref] == pref_name && patch[:city] == city_name && patch[:town] == town_name
+
+          # JS: _addr.replace(new RegExp(patch.pattern), patch.result)
+          # new RegExp は g フラグ無し（最初の 1 件のみ）なので sub。result は literal。
+          addr = addr.sub(::Regexp.new(patch[:pattern]), patch[:result])
+        end
+
+        addr
+      end
+    end
+    public_constant :PatchAddr
+  end
+end

--- a/sig/v4/patch_addr.rbs
+++ b/sig/v4/patch_addr.rbs
@@ -1,0 +1,12 @@
+# Interim signature for the v4.0.0 utility layer (M2).
+# The full RBS overhaul happens in M9.
+
+module JapaneseAddressParser
+  module V4
+    module PatchAddr
+      ADDR_PATCHES: Array[Hash[Symbol, String]]
+
+      def self.call: (String pref_name, String city_name, String town_name, String addr) -> String
+    end
+  end
+end

--- a/spec/v4/patch_addr_spec.rb
+++ b/spec/v4/patch_addr_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/patch_addr'
+
+::RSpec.describe(::JapaneseAddressParser::V4::PatchAddr) do
+  describe '.call' do
+    # 香川県 仲多度郡まんのう町 勝浦 のパッチ: '\A字?家[6六]' => '家六'
+    context 'when pref/city/town match the まんのう町 勝浦 patch' do
+      let(:pref) { '香川県'       }
+      let(:city) { '仲多度郡まんのう町' }
+      let(:town) { '勝浦'        }
+
+      it 'patches the half-width number form' do
+        expect(described_class.call(pref, city, town, '家6')).to(eq('家六'))
+      end
+
+      it 'patches the kanji number form' do
+        expect(described_class.call(pref, city, town, '家六')).to(eq('家六'))
+      end
+
+      it 'patches with the optional 字 prefix present' do
+        expect(described_class.call(pref, city, town, '字家6')).to(eq('家六'))
+      end
+
+      it 'replaces only the matched prefix and keeps the rest' do
+        expect(described_class.call(pref, city, town, '家6番地')).to(eq('家六番地'))
+      end
+
+      it 'leaves an address that does not match the pattern unchanged' do
+        expect(described_class.call(pref, city, town, '山田')).to(eq('山田'))
+      end
+    end
+
+    it 'applies the あま市 西今宿 patch' do
+      expect(described_class.call('愛知県', 'あま市', '西今宿', '梶村1')).to(eq('梶村一'))
+    end
+
+    it 'applies the 丸亀市 原田町 patch' do
+      expect(described_class.call('香川県', '丸亀市', '原田町', '字東三分一')).to(eq('東三分一'))
+    end
+
+    it 'does nothing when the town does not match any patch' do
+      expect(described_class.call('香川県', '仲多度郡まんのう町', '別の町', '字家6')).to(eq('字家6'))
+    end
+
+    # 始端アンカーの忠実性: JS の `^`（m フラグ無し）は文字列先頭のみにマッチする。
+    # Ruby の `^` は行頭にマッチしてしまうため `\A` へ翻訳済み。改行を挟んだ後続行の
+    # '家6' は文字列先頭ではないのでマッチしない（`^` 移植だと誤って '家六' に置換される）。
+    it 'anchors at the start of the string, not the start of a line (\\A, not ^)' do
+      expect(described_class.call('香川県', '仲多度郡まんのう町', '勝浦', "X\n家6")).to(eq("X\n家6"))
+    end
+  end
+end


### PR DESCRIPTION
## What

M2（ユーティリティ層）の `patch_addr`（3パッチ）を逐語移植する。特定の3町（まんのう町勝浦・あま市西今宿・丸亀市原田町）について番地表記のゆれを補正する。

移植元: [`src/lib/patchAddr.ts`](https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/lib/patchAddr.ts)（@geolonia/normalize-japanese-addresses v3.1.3）。

## 忠実移植の要点（specで固定）

- **`^` → `\A` 翻訳** — JS の `^`（m フラグ無し）は文字列先頭にマッチするが、Ruby の `^` は行頭にマッチする。verbatim コピーすると改行後の後続行に誤マッチするため、**挙動の忠実性を優先して `\A` へ翻訳**。改行を挟んだ `"X\n家6"` が不変であることを分岐テストで固定（`^` 移植なら誤って `X\n家六`）。
  - この方針（JS `^`/`$` → Ruby `\A`/`\z`）は M5（normalize.ts）でも多用される確定事項。
- `new RegExp`（g フラグ無し）→ `sub`（最初の1件のみ）。`字?家6` / `家6` / `家六` → `家六`、`家6番地 → 家六番地`。
- pref/city/town が一致したパッチのみ適用。3件を `{ pref:, city:, town:, pattern:, result: }` 定数配列として逐語コピー。

## 検証

- `rspec spec/v4/patch_addr_spec.rb` — 9 examples, 0 failures
- `rubocop` — no offenses
- `steep check` — No type error
- `/simplify` — 4観点 clean

## マイルストーン

M2 6ユニット目。`zen2han`✅ / `japanese_numeral`✅ / `kan2num`✅ / `dictionaries`✅ / `dict`✅ に続く。残りは `normalize_helpers` → `utils`。