### PR TITLE
feat(v4): add normalize_helpers prenormalize for M2

### DIFF
--- a/lib/japanese_address_parser/v4/normalize_helpers.rb
+++ b/lib/japanese_address_parser/v4/normalize_helpers.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/lib/normalizeHelpers.ts
+# Upstream: @geolonia/normalize-japanese-addresses v3.1.3
+
+require 'japanese_address_parser/v4/zen2han'
+
+module JapaneseAddressParser
+  module V4
+    # 入力住所に対する前正規化（prenormalize）。NFC 化・スペース正規化・全角英数の半角化・
+    # 数字に隣接する各種横棒のハイフン統一・丁目/区郡/番地以前のスペース削除を行う。
+    module NormalizeHelpers
+      # 数字の前後で統一する横棒（ハイフン・マイナス・長音記号・罫線等）の文字クラス。
+      DASH = /[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━]/.freeze
+      # JS: /([0-9０-９一二三四五六七八九〇十百千][横棒])|([横棒])[0-9０-９一二三四五六七八九〇十]/g
+      # 先頭側の数字クラスは「百千」を含むが、横棒の後ろ側は「十」までで非対称（上流のまま）。
+      NUMBER_ADJACENT_DASH = /([0-9０-９一二三四五六七八九〇十百千]#{DASH.source})|(#{DASH.source})[0-9０-９一二三四五六七八九〇十]/.freeze
+      # JS: /(.+)(丁目?|番(町|地|丁)|条|軒|線|(の|ノ)町|地割)/（g フラグ無し）
+      BEFORE_CHOME = /(.+)(丁目?|番(町|地|丁)|条|軒|線|(の|ノ)町|地割)/.freeze
+      # JS: /(.+)((郡.+(町|村))|((市|巿).+(区|區)))/（g フラグ無し）
+      BEFORE_KU_GUN = /(.+)((郡.+(町|村))|((市|巿).+(区|區)))/.freeze
+      # JS: /.+?[0-9一二三四五六七八九〇十百千]-/（g フラグ無し）
+      BEFORE_FIRST_NUMBER_DASH = /.+?[0-9一二三四五六七八九〇十百千]-/.freeze
+
+      private_constant :DASH
+      private_constant :NUMBER_ADJACENT_DASH
+      private_constant :BEFORE_CHOME
+      private_constant :BEFORE_KU_GUN
+      private_constant :BEFORE_FIRST_NUMBER_DASH
+
+      module_function
+
+      # JS: prenormalize(input)
+      # /g 有無を厳守する（前半 4 つは g=gsub、後半 3 つは g 無し=sub）。
+      def prenormalize(input)
+        input
+          .unicode_normalize(:nfc)
+          .gsub(/　/, ' ')
+          .gsub(/ +/, ' ')
+          .gsub(/([０-９Ａ-Ｚａ-ｚ]+)/) { |match| Zen2han.call(match) }
+          .gsub(NUMBER_ADJACENT_DASH) { |match| match.gsub(DASH, '-') }
+          .sub(BEFORE_CHOME) { |match| match.gsub(/ /, '') }
+          .sub(BEFORE_KU_GUN) { |match| match.gsub(/ /, '') }
+          .sub(BEFORE_FIRST_NUMBER_DASH) { |match| match.gsub(/ /, '') }
+      end
+    end
+    public_constant :NormalizeHelpers
+  end
+end

--- a/sig/v4/normalize_helpers.rbs
+++ b/sig/v4/normalize_helpers.rbs
@@ -1,0 +1,16 @@
+# Interim signature for the v4.0.0 utility layer (M2).
+# The full RBS overhaul happens in M9.
+
+module JapaneseAddressParser
+  module V4
+    module NormalizeHelpers
+      DASH: Regexp
+      NUMBER_ADJACENT_DASH: Regexp
+      BEFORE_CHOME: Regexp
+      BEFORE_KU_GUN: Regexp
+      BEFORE_FIRST_NUMBER_DASH: Regexp
+
+      def self.prenormalize: (String input) -> String
+    end
+  end
+end

--- a/spec/v4/normalize_helpers_spec.rb
+++ b/spec/v4/normalize_helpers_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/normalize_helpers'
+
+::RSpec.describe(::JapaneseAddressParser::V4::NormalizeHelpers) do
+  describe '.prenormalize' do
+    it 'normalizes a full-width space to a half-width space' do
+      expect(described_class.prenormalize('東京都　渋谷区')).to(eq('東京都 渋谷区'))
+    end
+
+    it 'collapses consecutive spaces into one' do
+      expect(described_class.prenormalize('東京都    渋谷区')).to(eq('東京都 渋谷区'))
+    end
+
+    it 'converts full-width alphanumerics to half-width' do
+      expect(described_class.prenormalize('Ａｂ１２３')).to(eq('Ab123'))
+    end
+
+    context 'with a horizontal bar adjacent to a number' do
+      it 'unifies a long-vowel mark to a hyphen' do
+        expect(described_class.prenormalize('1ー2')).to(eq('1-2'))
+      end
+
+      it 'unifies a full-width minus to a hyphen' do
+        expect(described_class.prenormalize('１−２')).to(eq('1-2'))
+      end
+
+      it 'unifies an em dash to a hyphen' do
+        expect(described_class.prenormalize('五—六')).to(eq('五-六'))
+      end
+    end
+
+    it 'leaves a horizontal bar that is not adjacent to a number unchanged' do
+      expect(described_class.prenormalize('あ—い')).to(eq('あ—い'))
+    end
+
+    # 横棒の前側の数字クラスは「百千」を含むが、後ろ側は「十」までで非対称（上流のまま）。
+    context 'with the asymmetric digit class around the dash' do
+      it 'unifies when 百 precedes the dash (百 is in the leading class)' do
+        expect(described_class.prenormalize('百ー')).to(eq('百-'))
+      end
+
+      it 'does not unify when 百 follows the dash (百 is absent from the trailing class)' do
+        expect(described_class.prenormalize('ー百')).to(eq('ー百'))
+      end
+    end
+
+    it 'removes spaces before the 丁目 part' do
+      expect(described_class.prenormalize('東京都 渋谷区 渋谷 １丁目')).to(eq('東京都渋谷区渋谷1丁目'))
+    end
+
+    it 'removes spaces before the 区 within a 市 (政令市)' do
+      expect(described_class.prenormalize('京都府 京都 市 北 区')).to(eq('京都府京都市北区'))
+    end
+
+    it 'removes spaces before the first number-hyphen run' do
+      expect(described_class.prenormalize('東京都 渋谷区 渋谷 1-2-3')).to(eq('東京都渋谷区渋谷1-2-3'))
+    end
+
+    it 'normalizes the string to NFC' do
+      # 分解形 か(U+304B) + 結合濁点(U+3099) を合成形 が(U+304C) へ正規化する。
+      decomposed = [0x304B, 0x3099].pack('U*')
+      composed = [0x304C].pack('U*')
+      expect(described_class.prenormalize(decomposed)).to(eq(composed))
+    end
+
+    it 'applies the whole pipeline to a realistic address' do
+      input = '神奈川県　横浜市港北区　大豆戸町　１７番地１１'
+      expect(described_class.prenormalize(input)).to(eq('神奈川県横浜市港北区大豆戸町17番地11'))
+    end
+  end
+end


### PR DESCRIPTION
## What

M2（ユーティリティ層）の `normalize_helpers`（`prenormalize`）を逐語移植する。住所の前正規化チェーン: NFC化・スペース正規化・全角英数の半角化・数字隣接の横棒のハイフン統一・丁目/区郡/番地以前のスペース削除。

移植元: [`src/lib/normalizeHelpers.ts`](https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/lib/normalizeHelpers.ts)（@geolonia/normalize-japanese-addresses v3.1.3）。

## 忠実移植の要点（specで固定）

- **`/g` 有無で gsub/sub を厳密に分離** — 前半4つ（全角空白→半角・連続空白圧縮・全角英数→半角・ダッシュ統一）は `gsub`、後半3つ（丁目前・区郡前・番地前のスペース削除）は `/g` 無し＝`sub`。
- **`normalize('NFC')` → `unicode_normalize(:nfc)`** — 分解形 か+結合濁点 → 合成形 が（コードポイント構築でテスト）。
- **非対称数字クラス** — 横棒の前は「百千」含む、後は「十」まで。`百ー → 百-` だが `ー百 → ー百` を固定。
- アンカー無しなので `\A` 翻訳不要。各種ダッシュは数字隣接時のみハイフン統一・非隣接は不変。
- ダッシュ文字クラス・look-alike（市/巿・区/區）は上流TSから厳密抽出。正規表現は frozen 定数化（行長対策、コンパイル結果は同一）。

## 検証

- `rspec spec/v4/normalize_helpers_spec.rb` — 14 examples, 0 failures
- `rubocop` — no offenses
- `steep check` — No type error
- `/simplify` — 4観点 clean

## マイルストーン

M2 7ユニット目。残りは `utils` のみ（これで M2 完了）。