### PR TITLE
feat(v4): add utils and complete M2 utility layer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -88,6 +88,7 @@ Style/StringHashKeys:
     - spec/v4/data/single_machi_aza_spec.rb
     - spec/v4/data/single_rsdt_spec.rb
     - spec/v4/data/single_chiban_spec.rb
+    - spec/v4/utils_spec.rb
 
     # 漢数字⇔数値の辞書は日本語の文字をキーにするため文字列キーのハッシュを許容する。
     - lib/japanese_address_parser/v4/**/*.rb

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -7,7 +7,7 @@
 
 - [x] **M0** 設計確定（ドキュメント整備）
 - [x] **M1** データモデル層（japanese-addresses-v2 型）
-- [ ] **M2** ユーティリティ層
+- [x] **M2** ユーティリティ層
 - [ ] **M3** 設定 & データアクセス層（config / fetcher）
 - [ ] **M4** cacheRegexes（level 3 まで）
 - [ ] **M5** normalize 本体（level 0–3）

--- a/lib/japanese_address_parser/v4/utils.rb
+++ b/lib/japanese_address_parser/v4/utils.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/lib/utils.ts
+# Upstream: @geolonia/normalize-japanese-addresses v3.1.3
+
+module JapaneseAddressParser
+  module V4
+    # 出力 metadata 用に、VO から余分なフィールドを取り除いたコピー（Hash）を作る。
+    module Utils
+      module_function
+
+      # JS: removeCitiesFromPrefecture(pref)
+      #   if (!pref) return undefined
+      #   const newPref = { ...pref }; delete newPref.cities; return newPref
+      # Data.define はフィールドを削除できないので、to_h でキー付き Hash 化してから
+      # cities キーを除く（JS の Omit<SinglePrefecture, 'cities'> 相当）。
+      def remove_cities_from_prefecture(pref)
+        return if pref.nil?
+
+        hash = pref.to_h
+        hash.delete(:cities)
+        hash
+      end
+
+      # JS: removeExtraFromMachiAza(machiAza)
+      #   if (!machiAza) return undefined
+      #   const newMachiAza = { ...machiAza }; delete newMachiAza.csv_ranges; return newMachiAza
+      def remove_extra_from_machi_aza(machi_aza)
+        return if machi_aza.nil?
+
+        hash = machi_aza.to_h
+        hash.delete(:csv_ranges)
+        hash
+      end
+    end
+    public_constant :Utils
+  end
+end

--- a/sig/v4/utils.rbs
+++ b/sig/v4/utils.rbs
@@ -1,0 +1,11 @@
+# Interim signature for the v4.0.0 utility layer (M2).
+# The full RBS overhaul happens in M9.
+
+module JapaneseAddressParser
+  module V4
+    module Utils
+      def self.remove_cities_from_prefecture: (untyped pref) -> (Hash[Symbol, untyped] | nil)
+      def self.remove_extra_from_machi_aza: (untyped machi_aza) -> (Hash[Symbol, untyped] | nil)
+    end
+  end
+end

--- a/spec/v4/utils_spec.rb
+++ b/spec/v4/utils_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/utils'
+require 'japanese_address_parser/v4/data/single_prefecture'
+require 'japanese_address_parser/v4/data/single_machi_aza'
+
+::RSpec.describe(::JapaneseAddressParser::V4::Utils) do
+  describe '.remove_cities_from_prefecture' do
+    subject(:result) { described_class.remove_cities_from_prefecture(prefecture) }
+
+    let(:prefecture) do
+      ::JapaneseAddressParser::V4::Data::SinglePrefecture.from_json('code' => 13, 'pref' => '東京都', 'pref_k' => 'トウキョウト', 'pref_r' => 'Tokyo', 'point' => [139.7, 35.6], 'cities' => [{ 'code' => 13_101 }])
+    end
+
+    context 'when the prefecture is nil' do
+      let(:prefecture) { nil }
+
+      it 'returns nil' do
+        expect(result).to(be_nil)
+      end
+    end
+
+    it 'returns a Hash without the cities key' do
+      expect(result).to(be_a(::Hash))
+      expect(result).not_to(have_key(:cities))
+    end
+
+    it 'keeps the other fields intact' do
+      expect(result).to(eq({ code: 13, pref: '東京都', pref_k: 'トウキョウト', pref_r: 'Tokyo', point: [139.7, 35.6] }))
+    end
+
+    it 'does not mutate the original prefecture' do
+      result
+      expect(prefecture.cities.size).to(eq(1))
+    end
+  end
+
+  describe '.remove_extra_from_machi_aza' do
+    subject(:result) { described_class.remove_extra_from_machi_aza(machi_aza) }
+
+    let(:machi_aza) do
+      ::JapaneseAddressParser::V4::Data::SingleMachiAza.from_json(
+        'machiaza_id' => '0001',
+        'oaza_cho' => '道玄坂',
+        'chome' => '一丁目',
+        'rsdt' => true,
+        'point' => [139.6, 35.6],
+        'csv_ranges' => { '住居表示' => { 'start' => 0, 'length' => 10 } }
+      )
+    end
+
+    context 'when the machi_aza is nil' do
+      let(:machi_aza) { nil }
+
+      it 'returns nil' do
+        expect(result).to(be_nil)
+      end
+    end
+
+    it 'returns a Hash without the csv_ranges key' do
+      expect(result).to(be_a(::Hash))
+      expect(result).not_to(have_key(:csv_ranges))
+    end
+
+    it 'keeps the other fields intact' do
+      expect(result[:machiaza_id]).to(eq('0001'))
+      expect(result[:oaza_cho]).to(eq('道玄坂'))
+      expect(result[:chome]).to(eq('一丁目'))
+      expect(result[:rsdt]).to(be(true))
+    end
+
+    it 'does not mutate the original machi_aza' do
+      result
+      expect(machi_aza.csv_ranges).not_to(be_nil)
+    end
+  end
+end


### PR DESCRIPTION
## What

M2（ユーティリティ層）最後のユニット `utils`（`remove_cities_from_prefecture` / `remove_extra_from_machi_aza`）を逐語移植し、**M2 を完了**する。

移植元: [`src/lib/utils.ts`](https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/lib/utils.ts)（@geolonia/normalize-japanese-addresses v3.1.3）。

## 忠実移植の要点（specで固定）

- JS の `{...obj}` ＋ `delete` ／ `Omit<T,'k'>` → Ruby は **`to_h` でキー付き Hash 化し該当キーを除去**。Data.define はフィールド削除不可のため。
- 戻り値は上流で `result.metadata.{prefecture, machiAza}`（生データ逃がし道）に格納されるため、typed VO ではなく Hash 返しが忠実（[normalize.ts L364/L407](https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/normalize.ts#L364)）。
- `nil` 入力 → `nil`（JS undefined→undefined）。`cities`/`csv_ranges` 除去・他フィールド保持・元VO非破壊を検証。

## このPRの内容

- `lib/japanese_address_parser/v4/utils.rb`（新規）
- `spec/v4/utils_spec.rb`（新規、8 examples）
- `sig/v4/utils.rbs`（新規）
- `.rubocop.yml` — `utils_spec.rb` を `Style/StringHashKeys` 除外に追加（M1 data spec 群と同理由）
- `docs/milestones.md` — **M2 にチェック**（milestones 規約に従い完了PRで更新）

## 検証

- `rspec spec/v4/utils_spec.rb` — 8 examples, 0 failures
- `rubocop` — no offenses
- `steep check` — No type error
- `/simplify` — 4観点 clean

## マイルストーン

🎉 **M2（ユーティリティ層）完了**: `zen2han` / `japanese_numeral` / `kan2num` / `dictionaries` / `dict` / `patch_addr` / `normalize_helpers` / `utils`。次は M3（設定 & データアクセス層）または M4。