### PR TITLE
feat(v4): add cacheRegexes and complete M4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,8 @@ Metrics/BlockLength:
   Exclude:
     - japanese_address_parser.gemspec
     - spec/**/*_spec.rb
+    # v4 の逐語移植では上流 JS の巨大なコールバック（getTownRegexPatterns 等）をそのまま写す。
+    - lib/japanese_address_parser/v4/**/*.rb
 
 # v4 リアーキの lib は上流 JS の逐語移植（working_agreement §3）。メソッド構成・
 # 複雑度・モジュール長は移植元 JS に合わせるため、これらの Metrics を v4 では緩める。
@@ -47,6 +49,17 @@ Style/InlineComment:
     - lib/japanese_address_parser/v4/**/*.rb
 
 Style/NumericPredicate:
+  Exclude:
+    - lib/japanese_address_parser/v4/**/*.rb
+
+# v4 は JS の関数名（getPrefectures 等）をそのまま get_* に移植するため許容する。
+Naming/AccessorMethodName:
+  Exclude:
+    - lib/japanese_address_parser/v4/**/*.rb
+
+# v4 は正規表現を文字列レベルで逐語コピーする（§3-1）。上流が文字クラス内に
+# リテラル `|` を含める癖（例: /[都|道|府|県]$/）もそのまま移植するため許容する。
+Lint/DuplicateRegexpCharacterClassElement:
   Exclude:
     - lib/japanese_address_parser/v4/**/*.rb
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     japanese_address_parser (3.2.0)
       csv
+      lru_redux
       schmooze
 
 GEM
@@ -35,6 +36,7 @@ GEM
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    lru_redux (1.1.0)
     minitest (5.19.0)
     parallel (1.22.1)
     parser (3.2.2.3)

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -9,7 +9,7 @@
 - [x] **M1** データモデル層（japanese-addresses-v2 型）
 - [x] **M2** ユーティリティ層
 - [x] **M3** 設定 & データアクセス層（config / fetcher）
-- [ ] **M4** cacheRegexes（level 3 まで）
+- [x] **M4** cacheRegexes（level 3 まで）
 - [ ] **M5** normalize 本体（level 0–3）
 - [ ] **M6** 公開 API & リッチ VO
 - [ ] **M7** テストスイート移植

--- a/japanese_address_parser.gemspec
+++ b/japanese_address_parser.gemspec
@@ -31,6 +31,7 @@ require_relative 'lib/japanese_address_parser/version'
   spec.require_paths = ['lib']
 
   spec.add_dependency('csv')
+  spec.add_dependency('lru_redux')
   spec.add_dependency('schmooze')
   spec.add_development_dependency('activesupport')
   spec.add_development_dependency('base64')

--- a/lib/japanese_address_parser/v4/cache_regexes.rb
+++ b/lib/japanese_address_parser/v4/cache_regexes.rb
@@ -1,0 +1,279 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/lib/cacheRegexes.ts
+# Upstream: @geolonia/normalize-japanese-addresses v3.1.3
+#   level 0-3 部分のみ。rsdt/chiban（getRsdt/getChiban/fetchSubresource/parseSubresource）は M8 で実装する。
+
+require 'set'
+require 'lru_redux'
+require 'japanese_address_parser/v4/config'
+require 'japanese_address_parser/v4/fetcher'
+require 'japanese_address_parser/v4/dict'
+require 'japanese_address_parser/v4/kan2num'
+require 'japanese_address_parser/v4/japanese_numeral'
+require 'japanese_address_parser/v4/data/prefecture_api'
+require 'japanese_address_parser/v4/data/machi_aza_api'
+
+module JapaneseAddressParser
+  module V4
+    # データ取得・キャッシュ・正規表現パターン生成（cacheRegexes.ts）。
+    # JS の `^`/`$`（m フラグ無し）は文字列先頭/末尾なので、生成パターンでは `\A`/`\z` に翻訳する
+    # （working_agreement §3-6）。スレッド安全性は考慮しない（§1-6）。
+    module CacheRegexes
+      # 「○○町」の省略エイリアス。JS では SingleMachiAza に originalTown を生やした部分オブジェクト。
+      # machi_aza_name は oaza_cho（町を除いた名前）を返す（chome/koaza は持たない）。
+      TownAlias =
+        ::Data.define(:machiaza_id, :point, :oaza_cho, :original_town) do
+          # JS: machiAzaName(town) 相当。エイリアスは oaza_cho（町を除いた名前）のみを持つ。
+          def machi_aza_name
+            oaza_cho
+          end
+        end
+      public_constant :TownAlias
+
+      module_function
+
+      # JS: const cache = new LRUCache({ max: currentConfig.cacheSize })
+      # 町字 regex パターンのみ LRU でキャッシュする（working_agreement §1-8）。
+      def cache
+        @cache ||= ::LruRedux::Cache.new(V4.config.cache_size)
+      end
+
+      # JS: fetchFromCache(key, fetcher)
+      def fetch_from_cache(key)
+        cached = cache[key]
+        return cached unless cached.nil?
+
+        data = yield
+        cache[key] = data
+        data
+      end
+
+      # JS: getPrefectures()
+      def get_prefectures
+        return @cached_prefectures unless @cached_prefectures.nil?
+
+        response = Fetcher.fetch('.json') # ja.json
+        cache_prefectures(Data::PrefectureApi.from_json(response.json))
+      end
+
+      # JS: cachePrefectures(data)
+      def cache_prefectures(data)
+        @cached_prefectures = data
+      end
+
+      # JS: getPrefectureRegexPatterns(api)
+      def get_prefecture_regex_patterns(api)
+        return @cached_prefecture_patterns if @cached_prefecture_patterns
+
+        @cached_prefecture_patterns =
+          api.data.map do |pref|
+            # JS: pref.pref.replace(/(都|道|府|県)$/, '') — 末尾の都府県が抜けた住所に対応（$ → \z）
+            pref_name = pref.pref.sub(/(都|道|府|県)\z/, '')
+            # JS: `^${_pref}(都|道|府|県)?`（^ → \A）
+            [pref, "\\A#{pref_name}(都|道|府|県)?"]
+          end
+      end
+
+      # JS: getCityRegexPatterns(pref)
+      def get_city_regex_patterns(pref)
+        cached = cached_city_patterns[pref.code]
+        return cached unless cached.nil?
+
+        # JS: cities.sort((a, b) => cityName(a).length - cityName(b).length)
+        # 少ない文字数の地名に対してミスマッチしないよう文字数の昇順に安定ソートする。
+        cities = stable_sort_by(pref.cities) { |city| city.city_name.length }
+
+        patterns =
+          cities.map do |city|
+            name = city.city_name
+            pattern = "\\A#{Dict.to_regex_pattern(name)}"
+            if name.match?(/(町|村)\z/) # JS: name.match(/(町|村)$/)
+              # JS: `^${toRegexPattern(name).replace(/(.+?)郡/, '($1郡)?')}` — 郡が省略されてるかも
+              pattern = "\\A#{Dict.to_regex_pattern(name).sub(/(.+?)郡/, '(\1郡)?')}"
+            end
+            [city, pattern]
+          end
+
+        cached_city_patterns[pref.code] = patterns
+      end
+
+      # JS: getTowns(prefObj, cityObj, apiVersion)
+      def get_towns(pref_obj, city_obj, api_version)
+        pref = pref_obj.prefecture_name
+        city = city_obj.city_name
+
+        cache_key = "#{pref}-#{city}"
+        cached = cached_towns[cache_key]
+        return cached unless cached.nil?
+
+        # JS: ['', encodeURI(pref), encodeURI(city) + `.json?v=${apiVersion}`].join('/')
+        # 非 ASCII のパーセントエンコードは Fetcher#http_request 側で一括して行う（二重エンコード回避）
+        # ため、ここでは encodeURI せず生の県名・市名を渡す。
+        input = ['', pref, "#{city}.json?v=#{api_version}"].join('/')
+        response = Fetcher.fetch(input)
+        cached_towns[cache_key] = Data::MachiAzaApi.from_json(response.json)
+      end
+
+      # JS: getTownRegexPatterns(pref, city, apiVersion)
+      def get_town_regex_patterns(pref, city, api_version)
+        fetch_from_cache("#{pref.code}-#{city.code}") do
+          api = get_towns(pref, city, api_version)
+          pre_towns = api.data
+          town_set = ::Set.new(pre_towns.map(&:machi_aza_name))
+          towns = []
+
+          is_kyoto = city.city == '京都市'
+
+          # 「○○町」が含まれるケースへの対応。通常は「町」の省略を同義語として許容するが、
+          # 「○○町」と「○○」が共存するケース・京都・漢数字を含むケースは省略を許容しない。
+          pre_towns.each do |town|
+            towns << town
+
+            original_town = town.machi_aza_name
+            next if original_town.index('町').nil? # JS: indexOf('町') === -1
+
+            # JS: originalTown.replace(/(?!^町)町/g, '') — 冒頭の「町」は除外（^ → \A）
+            town_abbr = original_town.gsub(/(?!\A町)町/, '')
+            next if is_kyoto
+            next if town_set.include?(town_abbr)
+            next if town_set.include?("大字#{town_abbr}")
+            next if kanji_number_followed_by_cho?(original_town)
+
+            # エイリアスとして町なしのパターンを登録
+            towns << TownAlias.new(machiaza_id: town.machiaza_id, point: town.point, oaza_cho: town_abbr, original_town: town)
+          end
+
+          # JS: towns.sort((a, b) => bLen - aLen)（大字始まりは優先度を下げる）— 文字数の降順に安定ソート
+          towns = stable_sort_by(towns) { |town| -town_sort_length(town) }
+
+          patterns =
+            towns.map do |town|
+              pattern = Dict.to_regex_pattern(town_pattern_source(town.machi_aza_name))
+              # JS: 'originalTown' in town ? town.originalTown : town
+              associated = town.is_a?(TownAlias) ? town.original_town : town
+              [associated, pattern]
+            end
+
+          # X丁目 の丁目なしの数字だけ許容するため、最後に数字だけ追加する。
+          towns.each do |town|
+            # JS: machiAzaName(town).match(/([^一二三四五六七八九十]+)([一二三四五六七八九十]+)(丁目?)/)
+            chome_match = town.machi_aza_name.match(/([^一二三四五六七八九十]+)([一二三四五六七八九十]+)(丁目?)/)
+            next unless chome_match
+
+            chome_name_part = chome_match[1]
+            chome_num = chome_match[2]
+            # JS: toRegexPattern(`^${chomeNamePart}(${chomeNum}|${kan2num(chomeNum)})`)（^ → \A）
+            pattern = Dict.to_regex_pattern("\\A#{chome_name_part}(#{chome_num}|#{Kan2num.call(chome_num)})")
+            patterns << [town, pattern]
+          end
+
+          patterns
+        end
+      end
+
+      # JS: getSameNamedPrefectureCityRegexPatterns(prefApi)
+      def get_same_named_prefecture_city_regex_patterns(pref_api)
+        return @cached_same_named_prefecture_city_regex_patterns unless @cached_same_named_prefecture_city_regex_patterns.nil?
+
+        pref_list = pref_api.data
+        # JS: pref.pref.replace(/[都|道|府|県]$/, '') — 文字クラス（| も含む）は上流のまま（$ → \z）
+        prefs = pref_list.map { |pref| pref.pref.sub(/[都|道|府|県]\z/, '') }
+
+        patterns = []
+        pref_list.each do |pref|
+          pref.cities.each do |city|
+            city_n = city.city_name
+
+            # 市の名前が別の都道府県名から始まっているケース（例: 福島県石川郡石川町）を考慮する。
+            prefs.each do |pref_name|
+              # JS: cityN.indexOf(_prefs[j]) === 0
+              patterns << ["#{pref.pref}#{city_n}", "\\A#{city_n}"] if city_n.start_with?(pref_name)
+            end
+          end
+        end
+
+        @cached_same_named_prefecture_city_regex_patterns = patterns
+      end
+
+      # JS: getRsdt(pref, city, town, apiVersion) — M8 で実装する。
+      def get_rsdt(_pref, _city, _town, _api_version)
+        raise(::NotImplementedError, 'getRsdt is implemented in M8 (level 8)')
+      end
+
+      # JS: getChiban(pref, city, town, apiVersion) — M8 で実装する。
+      def get_chiban(_pref, _city, _town, _api_version)
+        raise(::NotImplementedError, 'getChiban is implemented in M8 (level 8)')
+      end
+
+      # --- 内部ヘルパ ---
+
+      # 単純 Hash キャッシュ（全件）。LRU ではない（working_agreement §1-8）。
+      # JS: cachedCityPatterns（pref.code をキーにした市区町村パターンの全件 Hash キャッシュ）
+      def cached_city_patterns
+        @cached_city_patterns ||= {}
+      end
+
+      # JS: cachedTowns（"県-市" をキーにした町字一覧の全件 Hash キャッシュ）
+      def cached_towns
+        @cached_towns ||= {}
+      end
+
+      # JS の安定 Array.sort を再現する（Ruby の sort_by は非安定なので index でタイブレーク）。
+      def stable_sort_by(list)
+        list.each_with_index.sort_by { |item, index| [yield(item), index] }
+            .map(&:first)
+      end
+
+      # JS: aLen（大字始まりは -2 して優先度を下げる）
+      def town_sort_length(town)
+        name = town.machi_aza_name
+        name.start_with?('大字') ? name.length - 2 : name.length
+      end
+
+      # JS: isKanjiNumberFollewedByCho(targetTownName)（上流の関数名タイポはそのまま意図を移植）
+      # 「十六町」のように漢数字と町が連結しているか。
+      def kanji_number_followed_by_cho?(target_town_name)
+        x_cho = target_town_name.scan(/.町/) # JS: match(/.町/g)
+        return false if x_cho.empty?
+
+        !JapaneseNumeral.find_kanji_numbers(x_cho[0]).empty?
+      end
+
+      # JS: getTownRegexPatterns 内の machiAzaName(town).replace(...) チェーン（toRegexPattern へ渡す前段）。
+      def town_pattern_source(name)
+        name
+          # 横棒を含む場合（流通センター等）に対応
+          .gsub(/[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━]/, '[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━]')
+          .gsub(/大?字/, '(大?字)?')
+          # 町丁目に含まれる数字を正規表現へ。ABR データの全角数字（第１地割 等）にも一致させる。
+          .gsub(/([壱一二三四五六七八九十]+|[１２３４５６７８９０]+)(丁目?|番(町|丁)|条|軒|線|(の|ノ)町|地割|号)/) do |match|
+            expand_town_number(match)
+          end
+      end
+
+      # JS: getTownRegexPatterns 内の数字パターン展開コールバック。
+      def expand_town_number(match)
+        suffix = /(丁目?|番(町|丁)|条|軒|線|(の|ノ)町|地割|号)/
+        patterns = []
+        patterns << match.sub(suffix, '') # 漢数字（接尾辞を除く）
+
+        if match.match?(/\A壱/) # JS: match.match(/^壱/)（^ → \A）
+          patterns.push('一', '1', '１')
+        else
+          num = match
+                .gsub(/([一二三四五六七八九十]+)/) { |m| Kan2num.call(m) }
+                .gsub(/([１２３４５６７８９０]+)/) { |m| JapaneseNumeral.kanji2number(m).to_s }
+                .sub(suffix, '')
+          patterns << num # 半角アラビア数字
+        end
+
+        # 注: この正規表現は上のよく似た接尾辞パターンとは異なる（JS のコメントどおり）。
+        "(#{patterns.join('|')})((丁|町)目?|番(町|丁)|条|軒|線|の町?|地割|号|[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━])"
+      end
+
+      private_class_method :cached_city_patterns, :cached_towns, :stable_sort_by, :town_sort_length, :kanji_number_followed_by_cho?, :town_pattern_source, :expand_town_number
+    end
+    public_constant :CacheRegexes
+  end
+end

--- a/lib/japanese_address_parser/v4/data/api_meta.rb
+++ b/lib/japanese_address_parser/v4/data/api_meta.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/japanese-addresses-v2/blob/bb4d000ae136d8b8b571ebccd39a772cc6afc67a/src/data.ts
+# Upstream: @geolonia/japanese-addresses-v2 v0.0.5 (data spec for @geolonia/normalize-japanese-addresses v3.1.3)
+
+module JapaneseAddressParser
+  module V4
+    module Data
+      # API レスポンスの meta。`updated` はデータの更新時刻で、町字/サブリソース取得時の
+      # `?v={apiVersion}` に使う（キャッシュバスティング）。
+      ApiMeta =
+        ::Data.define(:updated) do
+          # JSON（パース済み Hash・文字列キー）から VO を生成する Ruby 独自ヘルパ。
+          def self.from_json(hash)
+            new(updated: hash['updated'])
+          end
+        end
+      public_constant :ApiMeta
+    end
+  end
+end

--- a/lib/japanese_address_parser/v4/data/machi_aza_api.rb
+++ b/lib/japanese_address_parser/v4/data/machi_aza_api.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/japanese-addresses-v2/blob/bb4d000ae136d8b8b571ebccd39a772cc6afc67a/src/data.ts
+# Upstream: @geolonia/japanese-addresses-v2 v0.0.5 (data spec for @geolonia/normalize-japanese-addresses v3.1.3)
+
+require 'japanese_address_parser/v4/data/api_meta'
+require 'japanese_address_parser/v4/data/single_machi_aza'
+
+module JapaneseAddressParser
+  module V4
+    module Data
+      # api/ja/{県}/{市}.json のレスポンス全体（町字一覧）。JS の MachiAzaApi。
+      MachiAzaApi =
+        ::Data.define(:meta, :data) do
+          # JSON（パース済み Hash・文字列キー）から VO を生成する Ruby 独自ヘルパ。
+          def self.from_json(hash)
+            new(meta: ApiMeta.from_json(hash['meta']), data: (hash['data'] || []).map { |machi_aza| SingleMachiAza.from_json(machi_aza) })
+          end
+        end
+      public_constant :MachiAzaApi
+    end
+  end
+end

--- a/lib/japanese_address_parser/v4/data/prefecture_api.rb
+++ b/lib/japanese_address_parser/v4/data/prefecture_api.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/japanese-addresses-v2/blob/bb4d000ae136d8b8b571ebccd39a772cc6afc67a/src/data.ts
+# Upstream: @geolonia/japanese-addresses-v2 v0.0.5 (data spec for @geolonia/normalize-japanese-addresses v3.1.3)
+
+require 'japanese_address_parser/v4/data/api_meta'
+require 'japanese_address_parser/v4/data/single_prefecture'
+
+module JapaneseAddressParser
+  module V4
+    module Data
+      # api/ja.json のレスポンス全体（全都道府県＋配下市区町村）。JS の PrefectureApi。
+      PrefectureApi =
+        ::Data.define(:meta, :data) do
+          # JSON（パース済み Hash・文字列キー）から VO を生成する Ruby 独自ヘルパ。
+          def self.from_json(hash)
+            new(meta: ApiMeta.from_json(hash['meta']), data: (hash['data'] || []).map { |pref| SinglePrefecture.from_json(pref) })
+          end
+        end
+      public_constant :PrefectureApi
+    end
+  end
+end

--- a/sig/v4/cache_regexes.rbs
+++ b/sig/v4/cache_regexes.rbs
@@ -1,0 +1,48 @@
+# Interim signature for the v4.0.0 config & data-access layer (M3/M4).
+# The full RBS overhaul happens in M9.
+#
+# LruRedux には RBS が無いため、キャッシュ関連は untyped で受ける。
+# 町字パターン配列の要素は SingleMachiAza か TownAlias の混在なので untyped にしている。
+
+module JapaneseAddressParser
+  module V4
+    module CacheRegexes
+      class TownAlias
+        attr_reader machiaza_id: String
+        attr_reader point: [Float, Float]?
+        attr_reader oaza_cho: String
+        attr_reader original_town: Data::SingleMachiAza
+
+        def self.new: (machiaza_id: String, point: [Float, Float]?, oaza_cho: String, original_town: Data::SingleMachiAza) -> instance
+        def machi_aza_name: () -> String
+      end
+
+      @cache: untyped
+      @cached_prefectures: Data::PrefectureApi?
+      @cached_prefecture_patterns: Array[[Data::SinglePrefecture, String]]?
+      @cached_city_patterns: Hash[Integer, Array[[Data::SingleCity, String]]]?
+      @cached_towns: Hash[String, Data::MachiAzaApi]?
+      @cached_same_named_prefecture_city_regex_patterns: Array[[String, String]]?
+
+      def self.cache: () -> untyped
+      def self.fetch_from_cache: (String key) { () -> untyped } -> untyped
+      def self.get_prefectures: () -> Data::PrefectureApi
+      def self.cache_prefectures: (Data::PrefectureApi data) -> Data::PrefectureApi
+      def self.get_prefecture_regex_patterns: (Data::PrefectureApi api) -> Array[[Data::SinglePrefecture, String]]
+      def self.get_city_regex_patterns: (Data::SinglePrefecture pref) -> Array[[Data::SingleCity, String]]
+      def self.get_towns: (Data::SinglePrefecture pref_obj, Data::SingleCity city_obj, Integer api_version) -> Data::MachiAzaApi
+      def self.get_town_regex_patterns: (Data::SinglePrefecture pref, Data::SingleCity city, Integer api_version) -> Array[[untyped, String]]
+      def self.get_same_named_prefecture_city_regex_patterns: (Data::PrefectureApi pref_api) -> Array[[String, String]]
+      def self.get_rsdt: (untyped pref, untyped city, untyped town, untyped api_version) -> bot
+      def self.get_chiban: (untyped pref, untyped city, untyped town, untyped api_version) -> bot
+
+      def self.cached_city_patterns: () -> Hash[Integer, Array[[Data::SingleCity, String]]]
+      def self.cached_towns: () -> Hash[String, Data::MachiAzaApi]
+      def self.stable_sort_by: (untyped list) { (untyped) -> untyped } -> untyped
+      def self.town_sort_length: (untyped town) -> Integer
+      def self.kanji_number_followed_by_cho?: (String target_town_name) -> bool
+      def self.town_pattern_source: (String name) -> String
+      def self.expand_town_number: (String match) -> String
+    end
+  end
+end

--- a/sig/v4/data.rbs
+++ b/sig/v4/data.rbs
@@ -83,6 +83,29 @@ module JapaneseAddressParser
 
         def chiban_to_string: () -> String
       end
+
+      class ApiMeta
+        attr_reader updated: Integer
+
+        def self.new: (updated: Integer) -> instance
+        def self.from_json: (Hash[String, untyped] hash) -> ApiMeta
+      end
+
+      class PrefectureApi
+        attr_reader meta: ApiMeta
+        attr_reader data: Array[SinglePrefecture]
+
+        def self.new: (meta: ApiMeta, data: Array[SinglePrefecture]) -> instance
+        def self.from_json: (Hash[String, untyped] hash) -> PrefectureApi
+      end
+
+      class MachiAzaApi
+        attr_reader meta: ApiMeta
+        attr_reader data: Array[SingleMachiAza]
+
+        def self.new: (meta: ApiMeta, data: Array[SingleMachiAza]) -> instance
+        def self.from_json: (Hash[String, untyped] hash) -> MachiAzaApi
+      end
     end
   end
 end

--- a/spec/v4/cache_regexes_spec.rb
+++ b/spec/v4/cache_regexes_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/cache_regexes'
+
+# 上流（main.test.ts）同様、既定エンドポイント＝ライブ CDN を叩く（working_agreement §1-8）。
+# モジュールのキャッシュはスイート内で共有してネットワーク呼び出しを抑える。
+::RSpec.describe(::JapaneseAddressParser::V4::CacheRegexes, :upstream_port) do
+  let(:api) { described_class.get_prefectures }
+  let(:kanagawa) do
+    described_class.get_prefecture_regex_patterns(api).find { |pref, _| pref.pref == '神奈川県' }
+                   .first
+  end
+  let(:kohoku) do
+    described_class.get_city_regex_patterns(kanagawa).find { |city, _| city.city_name == '横浜市港北区' }
+                   .first
+  end
+
+  describe '.get_prefectures' do
+    it 'fetches all 47 prefectures as a PrefectureApi' do
+      expect(api).to(be_a(::JapaneseAddressParser::V4::Data::PrefectureApi))
+      expect(api.data.size).to(eq(47))
+    end
+  end
+
+  describe '.get_prefecture_regex_patterns' do
+    subject(:pattern) do
+      described_class.get_prefecture_regex_patterns(api).find { |pref, _| pref.pref == '神奈川県' }
+                     .last
+    end
+
+    it 'anchors with \\A and tolerates the omitted 都道府県 suffix' do
+      expect(pattern).to(eq('\A神奈川(都|道|府|県)?'))
+      expect('神奈川県横浜市港北区'.match?(/#{pattern}/)).to(be(true))
+      expect('神奈川横浜市港北区'.match?(/#{pattern}/)).to(be(true))
+    end
+  end
+
+  describe '.get_city_regex_patterns' do
+    subject(:pattern) do
+      described_class.get_city_regex_patterns(kanagawa).find { |city, _| city.city_name == '横浜市港北区' }
+                     .last
+    end
+
+    it 'applies the dictionary conversion and matches the city' do
+      # 浜→(濱|浜)・市→(市|巿)・区→(區|区) のように両字体へ展開される
+      expect(pattern).to(start_with('\A横'))
+      expect('横浜市港北区大豆戸町'.match?(/#{pattern}/)).to(be(true))
+    end
+  end
+
+  describe '.get_towns' do
+    it 'fetches the town list as a MachiAzaApi' do
+      towns = described_class.get_towns(kanagawa, kohoku, api.meta.updated)
+
+      expect(towns).to(be_a(::JapaneseAddressParser::V4::Data::MachiAzaApi))
+      expect(towns.data).not_to(be_empty)
+    end
+  end
+
+  describe '.get_town_regex_patterns' do
+    subject(:patterns) { described_class.get_town_regex_patterns(kanagawa, kohoku, api.meta.updated) }
+
+    it 'generates a pattern that matches a representative address to its town' do
+      hit = patterns.find { |_, pat| '大豆戸町17番地11'.match?(/#{pat}/) }
+
+      expect(hit).not_to(be_nil)
+      expect(hit.first.machi_aza_name).to(include('大豆戸'))
+    end
+
+    it 'produces only valid regexes' do
+      expect(patterns).to(all(satisfy { |_, pat| ::Regexp.new(pat) }))
+    end
+
+    it 'caches the result (returns the same object on repeated calls)' do
+      first = described_class.get_town_regex_patterns(kanagawa, kohoku, api.meta.updated)
+
+      expect(described_class.get_town_regex_patterns(kanagawa, kohoku, api.meta.updated)).to(be(first))
+    end
+  end
+
+  describe '.cache' do
+    it 'is an LruRedux cache that evicts at config.cache_size' do
+      ::JapaneseAddressParser::V4.instance_variable_set(:@config, nil)
+      ::JapaneseAddressParser::V4.configure { |c| c.cache_size = 2 }
+      described_class.instance_variable_set(:@cache, nil)
+
+      cache = described_class.cache
+      expect(cache).to(be_a(::LruRedux::Cache))
+      cache[:a] = 1
+      cache[:b] = 2
+      # :c の追加で最古の :a が evict される
+      cache[:c] = 3
+
+      expect(cache.count).to(eq(2))
+      expect(cache.key?(:a)).to(be(false))
+    ensure
+      described_class.instance_variable_set(:@cache, nil)
+      ::JapaneseAddressParser::V4.instance_variable_set(:@config, nil)
+    end
+  end
+
+  describe '.get_same_named_prefecture_city_regex_patterns' do
+    it 'pairs a label with a \\A-anchored city pattern when a city starts with a prefecture name' do
+      patterns = described_class.get_same_named_prefecture_city_regex_patterns(api)
+
+      expect(patterns).to(include(['青森県青森市', '\A青森市']))
+    end
+  end
+
+  describe '.get_rsdt / .get_chiban (M8 stubs)' do
+    it 'raises NotImplementedError until M8' do
+      expect { described_class.get_rsdt(nil, nil, nil, nil) }
+        .to(raise_error(::NotImplementedError))
+      expect { described_class.get_chiban(nil, nil, nil, nil) }
+        .to(raise_error(::NotImplementedError))
+    end
+  end
+end


### PR DESCRIPTION
## What

M4（cacheRegexes、level 3 まで）を逐語移植し**完了**する。データ取得・キャッシュ・正規表現パターン生成。

移植元: [`src/lib/cacheRegexes.ts`](https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/lib/cacheRegexes.ts)（level 0-3 部分。rsdt/chiban は M8）。

## 内容

- `lib/.../v4/cache_regexes.rb`（新規）— `CacheRegexes`:
  - `get_prefectures` / `cache_prefectures` / `get_prefecture_regex_patterns`
  - `get_city_regex_patterns` / `get_same_named_prefecture_city_regex_patterns`
  - `get_towns` / `get_town_regex_patterns`（＋`TownAlias`・`is_kanji_number_followed_by_cho?` 等）
  - `get_rsdt` / `get_chiban` — **M8 スタブ**（`NotImplementedError` を raise）
  - キャッシュ: 都道府県/市/町字データは Hash 全件、町字 regex のみ `LruRedux::Cache`（config.cache_size）
- `lib/.../v4/data/{api_meta,prefecture_api,machi_aza_api}.rb`（新規）— meta ネスト保持の Api ラッパVO
- `spec/v4/cache_regexes_spec.rb`（新規、10 examples）— **ライブCDN直叩き**（上流 main.test.ts 同様、`:upstream_port`）
- `sig/v4/cache_regexes.rbs` ＋ `sig/v4/data.rbs` 追記
- `gemspec` ＋ `Gemfile.lock` — `lru_redux`（ランタイム依存）
- `.rubocop.yml` — v4 lib に3つの cop 除外（faithful-port 由来、コメント明記）

## 忠実移植の要点（ライブCDNで検証）

- pref `\A神奈川(都|道|府|県)?`（県省略許容）、city `\A横(濱|浜)(市|巿)港北(區|区)`（convert適用）、town 282件で `大豆戸町17番地11` がマッチ。
- **`^`/`$`→`\A`/`\z`**（§3-6）を生成パターンへ適用。**JS安定ソートを index タイブレークで再現**。`encodeURI` は fetcher 側に一元化（二重エンコード回避）。`TownAlias` で JS の `{...town, originalTown}` を再現。`[都|道|府|県]` の上流リテラル`|` も §3-2 で verbatim。

## 検証

- `rspec spec/v4/cache_regexes_spec.rb` — 10 examples, 0 failures
- v4 全体 — 132 examples, 0 failures
- `rubocop` / `steep check` — clean
- `/simplify` — clean（faithful-port/範囲外の3件は見送り。ダッシュ文字クラス共有定数化は M9 候補）

## 注意

CI でこの spec が**初めてライブCDNを叩く**（egress 既定許可で動作見込み）。CDN障害時は flaky になりうる。本格的なリトライ対策は M7。

## マイルストーン

🎉 **M4 完了**。次は **M5（normalize 本体、level 0–3）**。