### PR TITLE
feat(v4): add normalize body and complete M5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,6 +106,9 @@ Style/StringHashKeys:
     # HTTP ヘッダ名・クエリ名は文字列キーが自然なので許容する。
     - spec/v4/fetcher_spec.rb
 
+    # from_json に配信 API の JSON（文字列キー）を渡すため許容する。
+    - spec/v4/normalize_result_point_spec.rb
+
     # 漢数字⇔数値の辞書は日本語の文字をキーにするため文字列キーのハッシュを許容する。
     - lib/japanese_address_parser/v4/**/*.rb
 

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -10,7 +10,7 @@
 - [x] **M2** ユーティリティ層
 - [x] **M3** 設定 & データアクセス層（config / fetcher）
 - [x] **M4** cacheRegexes（level 3 まで）
-- [ ] **M5** normalize 本体（level 0–3）
+- [x] **M5** normalize 本体（level 0–3）
 - [ ] **M6** 公開 API & リッチ VO
 - [ ] **M7** テストスイート移植
 - [ ] **M8** level 8（rsdt / chiban）

--- a/lib/japanese_address_parser/v4/normalize.rb
+++ b/lib/japanese_address_parser/v4/normalize.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/normalize.ts
+# Upstream: @geolonia/normalize-japanese-addresses v3.1.3
+#   normalize（level 0-3、option.level <= 3 の早期 return まで）と normalizeTownName。
+#   level 8（normalizeAddrPart）は M8 で追加する。公開 API（JapaneseAddressParser.call）化は M6。
+
+require 'japanese_address_parser/v4/normalize_helpers'
+require 'japanese_address_parser/v4/cache_regexes'
+require 'japanese_address_parser/v4/patch_addr'
+require 'japanese_address_parser/v4/kan2num'
+require 'japanese_address_parser/v4/zen2han'
+require 'japanese_address_parser/v4/japanese_numeral'
+require 'japanese_address_parser/v4/utils'
+require 'japanese_address_parser/v4/normalize_result'
+require 'japanese_address_parser/v4/normalize_result_point'
+
+module JapaneseAddressParser
+  module V4
+    # 住所文字列を都道府県・市区町村・町字・番地へ正規化する（level 0-3）。
+    module Normalize
+      # JS: defaultOption = { level: 8 }
+      DEFAULT_LEVEL = 8
+
+      # 番地正規化で使う「半角数字 or 漢数字」の交替（1 キャプチャグループ）。
+      NUM = '([0-9]+|[〇一二三四五六七八九十百千]+)'
+      # 数字に隣接する横棒（ハイフン・マイナス・長音記号・罫線等）の文字クラス（上流 normalize.ts と同一）。
+      DASHES = '-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━'
+
+      private_constant :DEFAULT_LEVEL
+      private_constant :NUM
+      private_constant :DASHES
+
+      module_function
+
+      # JS: normalize(address, option)
+      def call(address, level: DEFAULT_LEVEL)
+        other = NormalizeHelpers.prenormalize(address)
+
+        # @type var pref: Data::SinglePrefecture?
+        pref = nil
+        # @type var city: Data::SingleCity?
+        city = nil
+        # @type var town: untyped
+        town = nil
+        # @type var point: NormalizeResultPoint?
+        point = nil
+        # @type var addr: String?
+        addr = nil
+
+        prefectures = CacheRegexes.get_prefectures
+        api_version = prefectures.meta.updated
+        pref_patterns = CacheRegexes.get_prefecture_regex_patterns(prefectures)
+        same_named_patterns = CacheRegexes.get_same_named_prefecture_city_regex_patterns(prefectures)
+
+        # 県名が省略されており市名がどこかの都道府県名と同じ場合（例: 千葉県千葉市）、県名を補完する。
+        same_named_patterns.each do |prefecture_city, reg|
+          regex = ::Regexp.new(reg)
+          next unless other.match?(regex)
+
+          other = other.sub(regex, prefecture_city) # JS: replace(new RegExp(reg), prefectureCity)（g 無し）
+          break
+        end
+
+        # 都道府県名の正規化
+        pref_patterns.each do |single_pref, pattern|
+          match = other.match(::Regexp.new(pattern))
+          next unless match
+
+          pref = single_pref
+          other = other[match[0].to_s.length..].to_s # 都道府県名以降の住所
+          point = ResultPoint.prefecture_to_result_point(single_pref)
+          break
+        end
+
+        unless pref
+          # 都道府県名が省略されている。全都道府県の市区町村パターンから候補を集める。
+          # @type var matched: Array[Hash[Symbol, untyped]]
+          matched = []
+          prefectures.data.each do |single_pref|
+            city_patterns = CacheRegexes.get_city_regex_patterns(single_pref)
+            other = other.strip
+            city_patterns.each do |single_city, pattern|
+              match = other.match(::Regexp.new(pattern))
+              matched << { pref: single_pref, city: single_city, other: other[match[0].to_s.length..].to_s } if match
+            end
+          end
+
+          if matched.length == 1
+            pref = matched[0][:pref]
+          else
+            # 複数候補は町名まで正規化して判別する（例: 東京都府中市 と 広島県府中市）。
+            matched.each do |candidate|
+              normalized = normalize_town_name(candidate[:other], candidate[:pref], candidate[:city], api_version)
+              next unless normalized
+
+              pref = candidate[:pref]
+              city = candidate[:city]
+              town = normalized[:town]
+              other = normalized[:other]
+              point = ResultPoint.upgrade_point(point, ResultPoint.machi_aza_to_result_point(town))
+            end
+          end
+        end
+
+        if pref && level >= 2
+          city_patterns = CacheRegexes.get_city_regex_patterns(pref)
+          other = other.strip
+          city_patterns.each do |single_city, pattern|
+            match = other.match(::Regexp.new(pattern))
+            next unless match
+
+            city = single_city
+            point = ResultPoint.upgrade_point(point, ResultPoint.city_to_result_point(single_city))
+            other = other[match[0].to_s.length..].to_s # 市区町村名以降の住所
+            break
+          end
+        end
+
+        # 町丁目以降の正規化
+        if pref && city && level >= 3
+          normalized = normalize_town_name(other, pref, city, api_version)
+          if normalized
+            town = normalized[:town]
+            other = normalized[:other]
+            point = ResultPoint.upgrade_point(point, ResultPoint.machi_aza_to_result_point(town))
+          end
+
+          # town が取得できた場合にのみ、番地正規化を行う。
+          other = normalize_addr(other) if town
+        end
+
+        other = PatchAddr.call(
+          pref ? pref.prefecture_name : '',
+          city ? city.city_name : '',
+          town ? town.machi_aza_name : '',
+          other
+        )
+
+        level_value = 0
+        level_value += 1 if pref
+        level_value += 1 if city
+        level_value += 1 if town
+
+        # JS: if (option.level <= 3 || level < 3) { return result }
+        # M8 で level 8（normalizeAddrPart）の分岐をここに追加する。M5 では常にこの結果を返す。
+        # metadata は VO に昇格しない生データの逃がし道（working_agreement §1-3）。
+        NormalizeResult.new(
+          pref: pref ? pref.prefecture_name : nil,
+          city: city ? city.city_name : nil,
+          town: town ? town.machi_aza_name : nil,
+          addr: addr,
+          other: other,
+          point: point,
+          level: level_value,
+          metadata: NormalizeResultMetadata.new(
+            input: address,
+            prefecture: Utils.remove_cities_from_prefecture(pref),
+            city: city,
+            machi_aza: Utils.remove_extra_from_machi_aza(town),
+            chiban: nil,
+            rsdt: nil
+          )
+        )
+      end
+
+      # JS: normalizeTownName(input, pref, city, apiVersion)
+      def normalize_town_name(input, pref, city, api_version)
+        input = input.strip.sub(/\A大字/, '') # JS: input.trim().replace(/^大字/, '')（^ → \A）
+        town_patterns = CacheRegexes.get_town_regex_patterns(pref, city, api_version)
+
+        regex_prefixes = ['\A'] # JS: ['^']（^ → \A）
+        regex_prefixes.push('.*') if city.city == '京都市' # 京都は通り名削除のため後方一致
+
+        regex_prefixes.each do |regex_prefix|
+          town_patterns.each do |town, pattern|
+            match = input.match(::Regexp.new("#{regex_prefix}#{pattern}"))
+            return { town: town, other: input[match[0].to_s.length..].to_s } if match
+          end
+        end
+
+        nil
+      end
+
+      # JS: 「町丁目以降の正規化」の replace チェーン（番地正規化）。順序込み逐語移植。
+      # /g の有無で gsub/sub を厳守し、$1 等は \1 に、^/$ は \A/\z に翻訳する。
+      def normalize_addr(other)
+        other
+          .sub(/\A-/, '')
+          .gsub(/([0-9]+)(丁目)/) { |match| match.gsub(/([0-9]+)/) { |num| JapaneseNumeral.number2kanji(Integer(num, 10)) } }
+          .sub(/(#{NUM}(番地?)#{NUM}号)\s*(.+)/, '\1 \5')
+          .sub(/#{NUM}\s*(番地?)\s*#{NUM}\s*号?/, '\1-\3')
+          .sub(/#{NUM}番(地|\z)/, '\1')
+          .gsub(/#{NUM}の/, '\1-')
+          .gsub(/#{NUM}[#{DASHES}]/) { |match| Kan2num.call(match).gsub(/[#{DASHES}]/, '-') }
+          .gsub(/[#{DASHES}]#{NUM}/) { |match| Kan2num.call(match).gsub(/[#{DASHES}]/, '-') }
+          .sub(/#{NUM}-/) { |s| Kan2num.call(s) } # `1-` のようなケース
+          .sub(/-#{NUM}/) { |s| Kan2num.call(s) } # `-1` のようなケース
+          .sub(/-[^0-9]#{NUM}/) { |s| Kan2num.call(Zen2han.call(s)) } # `-あ1` のようなケース
+          .sub(/#{NUM}\z/) { |s| Kan2num.call(s) } # `串本町串本１２３４` のようなケース
+          .strip
+      end
+
+      private_class_method :normalize_town_name, :normalize_addr
+    end
+    public_constant :Normalize
+  end
+end

--- a/lib/japanese_address_parser/v4/normalize_result.rb
+++ b/lib/japanese_address_parser/v4/normalize_result.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/types.ts
+# Upstream: @geolonia/normalize-japanese-addresses v3.1.3
+#   NormalizeResult / NormalizeResultMetadata。M5 では内部表現として使い、公開 VO 化は M6。
+
+require 'japanese_address_parser/v4/normalize_result_point'
+
+module JapaneseAddressParser
+  module V4
+    # JS: NormalizeResultMetadata。VO に昇格しない生データの逃がし道（working_agreement §1-3）。
+    # prefecture は cities を除いた Hash、machi_aza は csv_ranges を除いた Hash（M2 utils）。
+    # chiban / rsdt は M8 で埋まる（level 0-3 では nil）。
+    NormalizeResultMetadata = ::Data.define(:input, :prefecture, :city, :machi_aza, :chiban, :rsdt)
+    public_constant :NormalizeResultMetadata
+
+    # JS: NormalizeResult。addr は M8（level 8）で埋まる（level 0-3 では nil）。
+    NormalizeResult = ::Data.define(:pref, :city, :town, :addr, :other, :point, :level, :metadata)
+    public_constant :NormalizeResult
+  end
+end

--- a/lib/japanese_address_parser/v4/normalize_result_point.rb
+++ b/lib/japanese_address_parser/v4/normalize_result_point.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Port of: https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/types.ts
+# Upstream: @geolonia/normalize-japanese-addresses v3.1.3
+#   NormalizeResultPoint と座標変換ヘルパ（rsdtOrChibanToResultPoint は M8、
+#   isNormalizeResultPoint は公開 API 検証とともに M6 で移植する）。
+
+module JapaneseAddressParser
+  module V4
+    # 正規化結果の位置情報（EPSG:4326 / WGS84）。level は座標の正確さ（1:県 2:市 3:町字 8:住居表示/地番）。
+    NormalizeResultPoint = ::Data.define(:lat, :lng, :level)
+    public_constant :NormalizeResultPoint
+
+    # Single* VO（point は [lng, lat]）から NormalizeResultPoint を作る変換ヘルパ群。
+    module ResultPoint
+      module_function
+
+      # JS: prefectureToResultPoint(pref)
+      def prefecture_to_result_point(pref)
+        NormalizeResultPoint.new(lat: pref.point[1], lng: pref.point[0], level: 1)
+      end
+
+      # JS: cityToResultPoint(city)
+      def city_to_result_point(city)
+        NormalizeResultPoint.new(lat: city.point[1], lng: city.point[0], level: 2)
+      end
+
+      # JS: machiAzaToResultPoint(machiAza) — point が無ければ undefined
+      def machi_aza_to_result_point(machi_aza)
+        return if machi_aza.point.nil?
+
+        NormalizeResultPoint.new(lat: machi_aza.point[1], lng: machi_aza.point[0], level: 3)
+      end
+
+      # JS: upgradePoint(a, b) — より正確（level の大きい）方を採用する
+      def upgrade_point(point_a, point_b)
+        return point_b if point_a.nil?
+        return point_a if point_b.nil?
+        return point_a if point_a.level > point_b.level
+
+        point_b
+      end
+    end
+    public_constant :ResultPoint
+  end
+end

--- a/sig/v4/normalize.rbs
+++ b/sig/v4/normalize.rbs
@@ -1,0 +1,18 @@
+# Interim signature for the v4.0.0 normalize layer (M5).
+# The full RBS overhaul happens in M9.
+#
+# town は SingleMachiAza か TownAlias の混在なので untyped で受ける。
+
+module JapaneseAddressParser
+  module V4
+    module Normalize
+      DEFAULT_LEVEL: Integer
+      NUM: String
+      DASHES: String
+
+      def self.call: (String address, ?level: Integer) -> NormalizeResult
+      def self.normalize_town_name: (String input, Data::SinglePrefecture pref, Data::SingleCity city, Integer api_version) -> { town: untyped, other: String }?
+      def self.normalize_addr: (String other) -> String
+    end
+  end
+end

--- a/sig/v4/normalize_result.rbs
+++ b/sig/v4/normalize_result.rbs
@@ -1,0 +1,30 @@
+# Interim signature for the v4.0.0 normalize layer (M5).
+# The full RBS overhaul happens in M9.
+
+module JapaneseAddressParser
+  module V4
+    class NormalizeResultMetadata
+      attr_reader input: String
+      attr_reader prefecture: Hash[Symbol, untyped]?
+      attr_reader city: Data::SingleCity?
+      attr_reader machi_aza: Hash[Symbol, untyped]?
+      attr_reader chiban: untyped
+      attr_reader rsdt: untyped
+
+      def self.new: (input: String, prefecture: Hash[Symbol, untyped]?, city: Data::SingleCity?, machi_aza: Hash[Symbol, untyped]?, chiban: untyped, rsdt: untyped) -> instance
+    end
+
+    class NormalizeResult
+      attr_reader pref: String?
+      attr_reader city: String?
+      attr_reader town: String?
+      attr_reader addr: String?
+      attr_reader other: String
+      attr_reader point: NormalizeResultPoint?
+      attr_reader level: Integer
+      attr_reader metadata: NormalizeResultMetadata
+
+      def self.new: (pref: String?, city: String?, town: String?, addr: String?, other: String, point: NormalizeResultPoint?, level: Integer, metadata: NormalizeResultMetadata) -> instance
+    end
+  end
+end

--- a/sig/v4/normalize_result_point.rbs
+++ b/sig/v4/normalize_result_point.rbs
@@ -1,0 +1,21 @@
+# Interim signature for the v4.0.0 normalize layer (M5).
+# The full RBS overhaul happens in M9.
+
+module JapaneseAddressParser
+  module V4
+    class NormalizeResultPoint
+      attr_reader lat: Float
+      attr_reader lng: Float
+      attr_reader level: Integer
+
+      def self.new: (lat: Float, lng: Float, level: Integer) -> instance
+    end
+
+    module ResultPoint
+      def self.prefecture_to_result_point: (Data::SinglePrefecture pref) -> NormalizeResultPoint
+      def self.city_to_result_point: (Data::SingleCity city) -> NormalizeResultPoint
+      def self.machi_aza_to_result_point: (Data::SingleMachiAza machi_aza) -> NormalizeResultPoint?
+      def self.upgrade_point: (NormalizeResultPoint? point_a, NormalizeResultPoint? point_b) -> NormalizeResultPoint?
+    end
+  end
+end

--- a/spec/v4/normalize_result_point_spec.rb
+++ b/spec/v4/normalize_result_point_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/normalize_result_point'
+require 'japanese_address_parser/v4/data/single_prefecture'
+require 'japanese_address_parser/v4/data/single_city'
+require 'japanese_address_parser/v4/data/single_machi_aza'
+
+::RSpec.describe(::JapaneseAddressParser::V4::ResultPoint) do
+  # point は [lng, lat]。NormalizeResultPoint は lat/lng/level を持つ（level は座標の正確さ）。
+  describe '.prefecture_to_result_point' do
+    it 'maps pref.point [lng, lat] to lat/lng with level 1' do
+      pref = ::JapaneseAddressParser::V4::Data::SinglePrefecture.from_json('point' => [139.5, 35.6])
+      point = described_class.prefecture_to_result_point(pref)
+
+      expect(point.lng).to(eq(139.5))
+      expect(point.lat).to(eq(35.6))
+      expect(point.level).to(eq(1))
+    end
+  end
+
+  describe '.city_to_result_point' do
+    it 'maps city.point to lat/lng with level 2' do
+      city = ::JapaneseAddressParser::V4::Data::SingleCity.from_json('point' => [139.7, 35.4])
+      point = described_class.city_to_result_point(city)
+
+      expect(point.lat).to(eq(35.4))
+      expect(point.level).to(eq(2))
+    end
+  end
+
+  describe '.machi_aza_to_result_point' do
+    it 'maps machi_aza.point to lat/lng with level 3' do
+      machi_aza = ::JapaneseAddressParser::V4::Data::SingleMachiAza.from_json('point' => [139.6, 35.5])
+
+      expect(described_class.machi_aza_to_result_point(machi_aza).level).to(eq(3))
+    end
+
+    it 'returns nil when the machi_aza has no point' do
+      machi_aza = ::JapaneseAddressParser::V4::Data::SingleMachiAza.from_json({})
+
+      expect(described_class.machi_aza_to_result_point(machi_aza)).to(be_nil)
+    end
+  end
+
+  describe '.upgrade_point' do
+    let(:level1) { ::JapaneseAddressParser::V4::NormalizeResultPoint.new(lat: 1.0, lng: 1.0, level: 1) }
+    let(:level3) { ::JapaneseAddressParser::V4::NormalizeResultPoint.new(lat: 3.0, lng: 3.0, level: 3) }
+
+    it 'returns b when a is nil' do
+      expect(described_class.upgrade_point(nil, level1)).to(be(level1))
+    end
+
+    it 'returns a when b is nil' do
+      expect(described_class.upgrade_point(level1, nil)).to(be(level1))
+    end
+
+    it 'keeps the higher-level (more accurate) point' do
+      expect(described_class.upgrade_point(level3, level1)).to(be(level3))
+      expect(described_class.upgrade_point(level1, level3)).to(be(level3))
+    end
+  end
+end

--- a/spec/v4/normalize_spec.rb
+++ b/spec/v4/normalize_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/normalize'
+
+# 上流（main.test.ts）同様、既定エンドポイント＝ライブ CDN を叩く（working_agreement §1-8）。
+# 注: 緯度経度の厳密一致は検証しない。point.level（座標の正確さ）と pref/city/town/other のみ確認し、
+#     座標の近似一致マッチャ整備と緯度経度検証は M7 で行う。
+::RSpec.describe(::JapaneseAddressParser::V4::Normalize, :upstream_port) do
+  describe '.call' do
+    let(:address) { '神奈川県横浜市港北区大豆戸町１７番地１１' }
+
+    # 上流 main.test.ts の level 1/2/3 ケースをそのまま移植。
+    context 'with 神奈川県横浜市港北区大豆戸町１７番地１１' do
+      it 'normalizes to level 1' do
+        result = described_class.call(address, level: 1)
+
+        expect(result.pref).to(eq('神奈川県'))
+        expect(result.level).to(eq(1))
+        expect(result.point.level).to(eq(1))
+      end
+
+      it 'normalizes to level 2' do
+        result = described_class.call(address, level: 2)
+
+        expect(result.pref).to(eq('神奈川県'))
+        expect(result.city).to(eq('横浜市港北区'))
+        expect(result.level).to(eq(2))
+        expect(result.point.level).to(eq(2))
+      end
+
+      it 'normalizes to level 3 with the address remainder' do
+        result = described_class.call(address, level: 3)
+
+        expect(result.pref).to(eq('神奈川県'))
+        expect(result.city).to(eq('横浜市港北区'))
+        expect(result.town).to(eq('大豆戸町'))
+        expect(result.other).to(eq('17-11'))
+        expect(result.level).to(eq(3))
+        expect(result.point.level).to(eq(3))
+      end
+
+      it 'caps at level 3 with the default level (level 8 is M8)' do
+        expect(described_class.call(address).level).to(eq(3))
+      end
+    end
+
+    it 'completes an omitted prefecture when the city shares a prefecture name' do
+      # 千葉市 は県名「千葉」で始まるので 千葉県 を補完する。
+      result = described_class.call('千葉市中央区中央4-5-1', level: 3)
+
+      expect(result.pref).to(eq('千葉県'))
+      expect(result.city).to(eq('千葉市中央区'))
+      expect(result.town).to(eq('中央四丁目'))
+      expect(result.other).to(eq('5-1'))
+    end
+
+    it 'converts an arabic chome number to kanji inside the town' do
+      result = described_class.call('東京都渋谷区道玄坂2-10-8', level: 3)
+
+      expect(result.town).to(eq('道玄坂二丁目'))
+      expect(result.other).to(eq('10-8'))
+    end
+
+    it 'returns level 0 when nothing matches and leaves the address in other' do
+      result = described_class.call('あいうえお')
+
+      expect(result.pref).to(be_nil)
+      expect(result.level).to(eq(0))
+      expect(result.other).to(eq('あいうえお'))
+      expect(result.point).to(be_nil)
+    end
+
+    it 'stops at the requested level even when more could be matched' do
+      result = described_class.call(address, level: 1)
+
+      expect(result.city).to(be_nil)
+      expect(result.town).to(be_nil)
+    end
+
+    describe 'metadata' do
+      subject(:metadata) { described_class.call(address, level: 3).metadata }
+
+      it 'keeps the raw input' do
+        expect(metadata.input).to(eq(address))
+      end
+
+      it 'exposes prefecture as a Hash without the cities key' do
+        expect(metadata.prefecture).to(be_a(::Hash))
+        expect(metadata.prefecture).not_to(have_key(:cities))
+      end
+
+      it 'exposes machi_aza as a Hash without the csv_ranges key' do
+        expect(metadata.machi_aza).to(be_a(::Hash))
+        expect(metadata.machi_aza).not_to(have_key(:csv_ranges))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

M5（normalize 本体、level 0–3）を逐語移植し**完了**する。全体を束ねる中核。

移植元: [`src/normalize.ts`](https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/normalize.ts)（`option.level <= 3` 早期 return まで）＋ [`src/types.ts`](https://github.com/geolonia/normalize-japanese-addresses/blob/49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e/src/types.ts)（level 0-3 の座標ヘルパ・結果型）。

## 内容

- `lib/.../v4/normalize.rb`（新規）— `Normalize.call(address, level:)`: prenormalize → 都道府県（同名県市補完・県名省略判別）→ 市区町村 → 町字（`normalize_town_name`）→ **番地12段 replace チェーン**（`normalize_addr`）→ `patch_addr` → level 計算 → 内部 `NormalizeResult`。
- `lib/.../v4/normalize_result.rb` / `normalize_result_point.rb`（新規）— `NormalizeResult`/`NormalizeResultMetadata`/`NormalizeResultPoint`＋`ResultPoint` 変換。
- `spec/v4/normalize_spec.rb`（ライブCDN・`:upstream_port`）＋ `normalize_result_point_spec.rb`（純ユニット）。
- `sig/v4/normalize{,_result,_result_point}.rbs`、`.rubocop.yml`（StringHashKeys 除外1件）。

## 忠実移植の要点（ライブCDNで検証）

- main.test.ts の level 1/2/3（`神奈川県横浜市港北区大豆戸町１７番地１１` → other `17-11`）が完全一致。同名県市補完（`千葉市→千葉県千葉市中央区`）、京都通り名、level 0、丁目変換（`2→二丁目`）も確認。
- **番地12段チェーンを順序込み逐語**（`^`/`$`→`\A`/`\z` §3-6、`$1`→`\1`、gsub/sub 厳守、`number2kanji`/`kan2num`/`zen2han` コールバック）。`point.level`（1/2/3）連動。

## 明記した先送り

- **exact lat/lng 検証は M7**（spec に明記。現状は point.level ＋ pref/city/town/other を検証）。
- `level 8`/`addr`/`chiban`/`rsdt`/`normalizeAddrPart` は M8、公開API・`isNormalizeResultPoint` は M6。

## 検証

- `rspec`（normalize層）— 18 examples, 0 failures
- v4 全体 — 150 examples, 0 failures
- `rubocop` / `steep check` — clean
- `/simplify` — clean（faithful-port/M9/false-positive の3件は見送り）

## マイルストーン

🎉 **M5 完了**。次は **M6（公開 API & リッチ VO）**。