### PR TITLE
feat(v4): add public rich value objects (M6 PR1)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,6 +98,8 @@ Style/StringHashKeys:
     # 配信 API の JSON（文字列キー）を from_json に渡すため日本語/文字列キーのハッシュを許容する。
     - spec/v4/data/single_city_spec.rb
     - spec/v4/data/single_prefecture_spec.rb
+    - spec/v4/city_spec.rb
+    - spec/v4/address_spec.rb
     - spec/v4/data/single_machi_aza_spec.rb
     - spec/v4/data/single_rsdt_spec.rb
     - spec/v4/data/single_chiban_spec.rb

--- a/docs/rearchitecture.md
+++ b/docs/rearchitecture.md
@@ -132,8 +132,13 @@ Address = Data.define(
 
 Prefecture = Data.define(:name, :code, :name_kana, :name_romaji, :point)
 City       = Data.define(:name, :code, :county, :ward, :name_kana, :name_romaji, :point)
-Town       = Data.define(:name, :machiaza_id, :chome, :koaza, :point)
+Town       = Data.define(:name, :machiaza_id, :chome, :chome_n, :koaza, :point)
 ```
+
+> **M6 確定**: `Town` は `chome`（"一丁目" 等の文字列）と `chome_n`（1 等の整数）の両方を持つ。
+> JS の `SingleMachiAza` が両方を保持するため、リッチ VO でも JS と同じ情報量を一級フィールドで提供する。
+> 各 VO の `point` は `NormalizeResultPoint(lat, lng, level)`（§1-4 の忠実表現と一貫）。
+> 公開エントリは M9 まで `JapaneseAddressParser::V4.call/.call!`（旧トップレベル `call` と並存）、M9 で `JapaneseAddressParser.call` へ昇格する。
 
 > 旧 v2.x の独自付加情報（別 CSV 由来の furigana 等）は廃止。ただし**情報自体は v3 データから供給するため、kana/romaji/code は復活する**（出所が変わる）。`point` は `{lat, lng, level}` の表現で持つ。
 

--- a/lib/japanese_address_parser/v4/address.rb
+++ b/lib/japanese_address_parser/v4/address.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Public value object returned by the v4 API (M6).
+# Ruby-original enrichment layer over the faithful NormalizeResult (working_agreement §1-3 / rearchitecture §5.2)。
+# JS の NormalizeResult（文字列 pref/city/town）をネストしたリッチ VO に組み替える。
+
+require 'japanese_address_parser/v4/prefecture'
+require 'japanese_address_parser/v4/city'
+require 'japanese_address_parser/v4/town'
+
+module JapaneseAddressParser
+  module V4
+    # 正規化結果の公開 VO。prefecture/city/town は未判別なら nil（JS 同様、未マッチは失敗ではない）。
+    # metadata は VO に昇格しない生データ（rsdt/chiban 等）の逃がし道（working_agreement §1-3）。
+    Address =
+      ::Data.define(:full_address, :prefecture, :city, :town, :addr, :other, :point, :level, :metadata) do
+        # 内部 NormalizeResult（M5）から公開 Address を組み立てる。
+        def self.from_normalize_result(result)
+          metadata = result.metadata
+          new(
+            full_address: metadata.input,
+            prefecture: Prefecture.from_metadata(metadata.prefecture),
+            city: City.from_metadata(metadata.city),
+            town: Town.from_metadata(metadata.machi_aza),
+            addr: result.addr,
+            other: result.other,
+            point: result.point,
+            level: result.level,
+            metadata: metadata
+          )
+        end
+
+        # ネストした VO・座標も含めて Hash 化する Ruby 独自 API。metadata は生データの逃がし道として
+        # shallow に Hash 化する（内部の SingleCity 等は VO のまま）。
+        def to_h
+          {
+            full_address: full_address,
+            prefecture: prefecture&.to_h,
+            city: city&.to_h,
+            town: town&.to_h,
+            addr: addr,
+            other: other,
+            point: point&.to_h,
+            level: level,
+            metadata: metadata.to_h
+          }
+        end
+      end
+    public_constant :Address
+  end
+end

--- a/lib/japanese_address_parser/v4/city.rb
+++ b/lib/japanese_address_parser/v4/city.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Rich value object exposed by the v4 public API (M6).
+# Ruby-original enrichment layer over the faithful NormalizeResult (working_agreement §1-3).
+# 供給元: NormalizeResult#metadata.city（SingleCity VO）。
+
+require 'japanese_address_parser/v4/normalize_result_point'
+
+module JapaneseAddressParser
+  module V4
+    # 市区町村のリッチ VO。name は cityName（郡＋市＋政令区）。point は代表点（NormalizeResultPoint, level 2）。
+    City =
+      ::Data.define(:name, :code, :county, :ward, :name_kana, :name_romaji, :point) do
+        # metadata.city（SingleCity VO）から VO を作る。city 未判別なら nil。
+        def self.from_metadata(city)
+          return if city.nil?
+
+          new(name: city.city_name, code: city.code, county: city.county, ward: city.ward, name_kana: city.city_k, name_romaji: city.city_r, point: ResultPoint.city_to_result_point(city))
+        end
+
+        # 緯度経度をネストも含めて Hash 化する Ruby 独自 API。
+        def to_h
+          { name: name, code: code, county: county, ward: ward, name_kana: name_kana, name_romaji: name_romaji, point: point.to_h }
+        end
+      end
+    public_constant :City
+  end
+end

--- a/lib/japanese_address_parser/v4/normalize_result_point.rb
+++ b/lib/japanese_address_parser/v4/normalize_result_point.rb
@@ -8,7 +8,17 @@
 module JapaneseAddressParser
   module V4
     # 正規化結果の位置情報（EPSG:4326 / WGS84）。level は座標の正確さ（1:県 2:市 3:町字 8:住居表示/地番）。
-    NormalizeResultPoint = ::Data.define(:lat, :lng, :level)
+    NormalizeResultPoint =
+      ::Data.define(:lat, :lng, :level) do
+        # Ruby 独自の補助コンストラクタ: [lng, lat] 配列（無ければ nil）から VO を作る。
+        # 上流 types.ts の *ToResultPoint は VO の .point を直接受けるため逐語移植のまま残し、
+        # metadata の Hash（[lng, lat] 配列）から組み立てる M6 リッチ VO 層はこのファクトリを共有する。
+        def self.from_lng_lat(point, level:)
+          return if point.nil?
+
+          new(lat: point[1], lng: point[0], level: level)
+        end
+      end
     public_constant :NormalizeResultPoint
 
     # Single* VO（point は [lng, lat]）から NormalizeResultPoint を作る変換ヘルパ群。

--- a/lib/japanese_address_parser/v4/prefecture.rb
+++ b/lib/japanese_address_parser/v4/prefecture.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Rich value object exposed by the v4 public API (M6).
+# Ruby-original enrichment layer over the faithful NormalizeResult (working_agreement §1-3).
+# 供給元: NormalizeResult#metadata.prefecture（Omit<SinglePrefecture, 'cities'> 相当の Hash）。
+
+require 'japanese_address_parser/v4/normalize_result_point'
+
+module JapaneseAddressParser
+  module V4
+    # 都道府県のリッチ VO。point は代表点（NormalizeResultPoint, level 1）。
+    Prefecture =
+      ::Data.define(:name, :code, :name_kana, :name_romaji, :point) do
+        # metadata.prefecture（cities を除いた Hash・Symbol キー）から VO を作る。pref 未判別なら nil。
+        # point（level 1 代表点）は都道府県データに必ず存在する（from_lng_lat は nil 受けも安全）。
+        def self.from_metadata(hash)
+          return if hash.nil?
+
+          new(name: hash[:pref], code: hash[:code], name_kana: hash[:pref_k], name_romaji: hash[:pref_r], point: NormalizeResultPoint.from_lng_lat(hash[:point], level: 1))
+        end
+
+        # 緯度経度をネストも含めて Hash 化する Ruby 独自 API。
+        def to_h
+          { name: name, code: code, name_kana: name_kana, name_romaji: name_romaji, point: point.to_h }
+        end
+      end
+    public_constant :Prefecture
+  end
+end

--- a/lib/japanese_address_parser/v4/town.rb
+++ b/lib/japanese_address_parser/v4/town.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Rich value object exposed by the v4 public API (M6).
+# Ruby-original enrichment layer over the faithful NormalizeResult (working_agreement §1-3).
+# 供給元: NormalizeResult#metadata.machi_aza（Omit<SingleMachiAza, 'csv_ranges'> 相当の Hash）。
+
+require 'japanese_address_parser/v4/normalize_result_point'
+
+module JapaneseAddressParser
+  module V4
+    # 町字のリッチ VO。name は machiAzaName（大字＋丁目＋小字）。point は代表点（NormalizeResultPoint, level 3）。
+    # chome は "一丁目" 等の文字列、chome_n は 1 等の整数（JS SingleMachiAza が両方持つため両方公開する）。
+    Town =
+      ::Data.define(:name, :machiaza_id, :chome, :chome_n, :koaza, :point) do
+        # metadata.machi_aza（csv_ranges を除いた Hash・Symbol キー）から VO を作る。town 未判別なら nil。
+        # point（level 3 代表点）は町字によっては存在しないため from_lng_lat が nil を返す。
+        # name は Hash 入力のため SingleMachiAza#machi_aza_name を呼べない。式は同メソッド（JS: machiAzaName）と一致させる。
+        def self.from_metadata(hash)
+          return if hash.nil?
+
+          new(
+            name: "#{hash[:oaza_cho]}#{hash[:chome]}#{hash[:koaza]}",
+            machiaza_id: hash[:machiaza_id],
+            chome: hash[:chome],
+            chome_n: hash[:chome_n],
+            koaza: hash[:koaza],
+            point: NormalizeResultPoint.from_lng_lat(hash[:point], level: 3)
+          )
+        end
+
+        # 緯度経度をネストも含めて Hash 化する Ruby 独自 API。
+        def to_h
+          { name: name, machiaza_id: machiaza_id, chome: chome, chome_n: chome_n, koaza: koaza, point: point&.to_h }
+        end
+      end
+    public_constant :Town
+  end
+end

--- a/sig/v4/address.rbs
+++ b/sig/v4/address.rbs
@@ -1,0 +1,64 @@
+# Interim signature for the v4.0.0 public value objects (M6).
+# The full RBS overhaul happens in M9.
+#
+# These are `Data.define` value objects, but the bundled RBS (rbs 2.6.0) predates the
+# core `Data` class, so they are declared as plain classes exposing the interface we use.
+
+module JapaneseAddressParser
+  module V4
+    class Prefecture
+      attr_reader name: String
+      attr_reader code: Integer
+      attr_reader name_kana: String
+      attr_reader name_romaji: String
+      attr_reader point: NormalizeResultPoint
+
+      def self.new: (name: String, code: Integer, name_kana: String, name_romaji: String, point: NormalizeResultPoint) -> instance
+      def self.from_metadata: (Hash[Symbol, untyped]? hash) -> Prefecture?
+      def to_h: () -> Hash[Symbol, untyped]
+    end
+
+    class City
+      attr_reader name: String
+      attr_reader code: Integer
+      attr_reader county: String?
+      attr_reader ward: String?
+      attr_reader name_kana: String
+      attr_reader name_romaji: String
+      attr_reader point: NormalizeResultPoint
+
+      def self.new: (name: String, code: Integer, county: String?, ward: String?, name_kana: String, name_romaji: String, point: NormalizeResultPoint) -> instance
+      def self.from_metadata: (Data::SingleCity? city) -> City?
+      def to_h: () -> Hash[Symbol, untyped]
+    end
+
+    class Town
+      attr_reader name: String
+      attr_reader machiaza_id: String
+      attr_reader chome: String?
+      attr_reader chome_n: Integer?
+      attr_reader koaza: String?
+      attr_reader point: NormalizeResultPoint?
+
+      def self.new: (name: String, machiaza_id: String, chome: String?, chome_n: Integer?, koaza: String?, point: NormalizeResultPoint?) -> instance
+      def self.from_metadata: (Hash[Symbol, untyped]? hash) -> Town?
+      def to_h: () -> Hash[Symbol, untyped]
+    end
+
+    class Address
+      attr_reader full_address: String
+      attr_reader prefecture: Prefecture?
+      attr_reader city: City?
+      attr_reader town: Town?
+      attr_reader addr: String?
+      attr_reader other: String
+      attr_reader point: NormalizeResultPoint?
+      attr_reader level: Integer
+      attr_reader metadata: NormalizeResultMetadata
+
+      def self.new: (full_address: String, prefecture: Prefecture?, city: City?, town: Town?, addr: String?, other: String, point: NormalizeResultPoint?, level: Integer, metadata: NormalizeResultMetadata) -> instance
+      def self.from_normalize_result: (NormalizeResult result) -> Address
+      def to_h: () -> Hash[Symbol, untyped]
+    end
+  end
+end

--- a/sig/v4/normalize_result.rbs
+++ b/sig/v4/normalize_result.rbs
@@ -12,6 +12,7 @@ module JapaneseAddressParser
       attr_reader rsdt: untyped
 
       def self.new: (input: String, prefecture: Hash[Symbol, untyped]?, city: Data::SingleCity?, machi_aza: Hash[Symbol, untyped]?, chiban: untyped, rsdt: untyped) -> instance
+      def to_h: () -> Hash[Symbol, untyped]
     end
 
     class NormalizeResult

--- a/sig/v4/normalize_result_point.rbs
+++ b/sig/v4/normalize_result_point.rbs
@@ -9,6 +9,8 @@ module JapaneseAddressParser
       attr_reader level: Integer
 
       def self.new: (lat: Float, lng: Float, level: Integer) -> instance
+      def self.from_lng_lat: ([Float, Float]? point, level: Integer) -> NormalizeResultPoint?
+      def to_h: () -> Hash[Symbol, untyped]
     end
 
     module ResultPoint

--- a/spec/v4/address_spec.rb
+++ b/spec/v4/address_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/address'
+require 'japanese_address_parser/v4/normalize_result'
+require 'japanese_address_parser/v4/normalize_result_point'
+require 'japanese_address_parser/v4/data/single_city'
+
+::RSpec.describe(::JapaneseAddressParser::V4::Address) do
+  describe '.from_normalize_result' do
+    context 'with a fully matched result (level 3)' do
+      subject(:address) { described_class.from_normalize_result(result) }
+
+      let(:single_city) do
+        ::JapaneseAddressParser::V4::Data::SingleCity.from_json(
+          'code' => 14_109,
+          'city' => '横浜市',
+          'city_k' => 'ヨコハマシ',
+          'city_r' => 'Yokohama-shi',
+          'ward' => '港北区',
+          'ward_k' => 'コウホクク',
+          'ward_r' => 'Kohoku-ku',
+          'point' => [139.631, 35.507]
+        )
+      end
+      let(:metadata) do
+        ::JapaneseAddressParser::V4::NormalizeResultMetadata.new(
+          input: '神奈川県横浜市港北区大豆戸町一丁目',
+          prefecture: { code: 14, pref: '神奈川県', pref_k: 'カナガワケン', pref_r: 'Kanagawa', point: [139.642, 35.447] },
+          city: single_city,
+          machi_aza: { machiaza_id: '0001001', oaza_cho: '大豆戸町', chome: '一丁目', chome_n: 1, koaza: nil, point: [139.625, 35.508] },
+          chiban: nil,
+          rsdt: nil
+        )
+      end
+      let(:result) do
+        ::JapaneseAddressParser::V4::NormalizeResult.new(
+          pref: '神奈川県',
+          city: '横浜市港北区',
+          town: '大豆戸町一丁目',
+          addr: nil,
+          other: '',
+          point: ::JapaneseAddressParser::V4::NormalizeResultPoint.new(lat: 35.508, lng: 139.625, level: 3),
+          level: 3,
+          metadata: metadata
+        )
+      end
+
+      it 'maps the original input to full_address' do
+        expect(address.full_address).to(eq('神奈川県横浜市港北区大豆戸町一丁目'))
+      end
+
+      it 'builds the nested rich VOs' do
+        expect(address.prefecture.name).to(eq('神奈川県'))
+        expect(address.city.name).to(eq('横浜市港北区'))
+        expect(address.town.name).to(eq('大豆戸町一丁目'))
+        expect(address.town.chome_n).to(eq(1))
+      end
+
+      it 'passes through addr/other/point/level and keeps metadata as the raw escape hatch' do
+        expect(address.addr).to(be_nil)
+        expect(address.other).to(eq(''))
+        expect(address.point.level).to(eq(3))
+        expect(address.level).to(eq(3))
+        expect(address.metadata).to(equal(metadata))
+      end
+    end
+
+    context 'with an unmatched result (level 0)' do
+      subject(:address) { described_class.from_normalize_result(result) }
+
+      let(:metadata) do
+        ::JapaneseAddressParser::V4::NormalizeResultMetadata.new(input: 'まったく住所ではない文字列', prefecture: nil, city: nil, machi_aza: nil, chiban: nil, rsdt: nil)
+      end
+      let(:result) do
+        ::JapaneseAddressParser::V4::NormalizeResult.new(pref: nil, city: nil, town: nil, addr: nil, other: 'まったく住所ではない文字列', point: nil, level: 0, metadata: metadata)
+      end
+
+      it 'leaves the nested VOs nil (unmatched is not a failure)' do
+        expect(address.prefecture).to(be_nil)
+        expect(address.city).to(be_nil)
+        expect(address.town).to(be_nil)
+        expect(address.level).to(eq(0))
+        expect(address.point).to(be_nil)
+      end
+    end
+  end
+
+  describe '#to_h' do
+    let(:metadata) do
+      ::JapaneseAddressParser::V4::NormalizeResultMetadata.new(input: 'まったく住所ではない文字列', prefecture: nil, city: nil, machi_aza: nil, chiban: nil, rsdt: nil)
+    end
+    let(:result) do
+      ::JapaneseAddressParser::V4::NormalizeResult.new(pref: nil, city: nil, town: nil, addr: nil, other: 'まったく住所ではない文字列', point: nil, level: 0, metadata: metadata)
+    end
+
+    it 'deep-converts nested VOs and shallow-converts metadata' do
+      expect(described_class.from_normalize_result(result).to_h).to(
+        eq(
+          full_address: 'まったく住所ではない文字列',
+          prefecture: nil,
+          city: nil,
+          town: nil,
+          addr: nil,
+          other: 'まったく住所ではない文字列',
+          point: nil,
+          level: 0,
+          metadata: {
+            input: 'まったく住所ではない文字列',
+            prefecture: nil,
+            city: nil,
+            machi_aza: nil,
+            chiban: nil,
+            rsdt: nil
+          }
+        )
+      )
+    end
+  end
+end

--- a/spec/v4/city_spec.rb
+++ b/spec/v4/city_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/city'
+require 'japanese_address_parser/v4/data/single_city'
+
+::RSpec.describe(::JapaneseAddressParser::V4::City) do
+  describe '.from_metadata' do
+    context 'with nil (city not detected)' do
+      it 'returns nil' do
+        expect(described_class.from_metadata(nil)).to(be_nil)
+      end
+    end
+
+    context 'with a plain city (no county, no ward)' do
+      subject(:city) { described_class.from_metadata(single_city) }
+
+      let(:single_city) do
+        ::JapaneseAddressParser::V4::Data::SingleCity.from_json('code' => 12_025, 'city' => '函館市', 'city_k' => 'ハコダテシ', 'city_r' => 'Hakodate-shi', 'point' => [140.729108, 41.768712])
+      end
+
+      it 'maps name (cityName)/code/kana/romaji and leaves county/ward nil' do
+        expect(city.name).to(eq('函館市'))
+        expect(city.code).to(eq(12_025))
+        expect(city.county).to(be_nil)
+        expect(city.ward).to(be_nil)
+        expect(city.name_kana).to(eq('ハコダテシ'))
+        expect(city.name_romaji).to(eq('Hakodate-shi'))
+      end
+
+      it 'builds a level-2 representative point with lat/lng swapped from [lng, lat]' do
+        expect(city.point.lat).to(eq(41.768712))
+        expect(city.point.lng).to(eq(140.729108))
+        expect(city.point.level).to(eq(2))
+      end
+    end
+
+    context 'with a designated-city ward' do
+      subject(:city) { described_class.from_metadata(single_city) }
+
+      let(:single_city) do
+        ::JapaneseAddressParser::V4::Data::SingleCity.from_json(
+          'code' => 14_103,
+          'city' => '横浜市',
+          'city_k' => 'ヨコハマシ',
+          'city_r' => 'Yokohama-shi',
+          'ward' => '港北区',
+          'ward_k' => 'コウホクク',
+          'ward_r' => 'Kohoku-ku',
+          'point' => [139.631389, 35.494722]
+        )
+      end
+
+      it 'composes name from city + ward and exposes ward' do
+        expect(city.name).to(eq('横浜市港北区'))
+        expect(city.ward).to(eq('港北区'))
+      end
+    end
+  end
+
+  describe '#to_h' do
+    it 'deep-converts the nested point' do
+      single_city = ::JapaneseAddressParser::V4::Data::SingleCity.from_json('code' => 12_025, 'city' => '函館市', 'city_k' => 'ハコダテシ', 'city_r' => 'Hakodate-shi', 'point' => [140.729108, 41.768712])
+
+      expect(described_class.from_metadata(single_city).to_h).to(
+        eq(
+          name: '函館市',
+          code: 12_025,
+          county: nil,
+          ward: nil,
+          name_kana: 'ハコダテシ',
+          name_romaji: 'Hakodate-shi',
+          point: { lat: 41.768712, lng: 140.729108, level: 2 }
+        )
+      )
+    end
+  end
+end

--- a/spec/v4/normalize_result_point_factory_spec.rb
+++ b/spec/v4/normalize_result_point_factory_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/normalize_result_point'
+
+::RSpec.describe(::JapaneseAddressParser::V4::NormalizeResultPoint) do
+  describe '.from_lng_lat' do
+    it 'builds a point from a [lng, lat] array with the given level' do
+      point = described_class.from_lng_lat([139.6, 35.5], level: 3)
+
+      expect(point.lat).to(eq(35.5))
+      expect(point.lng).to(eq(139.6))
+      expect(point.level).to(eq(3))
+    end
+
+    it 'returns nil when the point array is nil' do
+      expect(described_class.from_lng_lat(nil, level: 3)).to(be_nil)
+    end
+  end
+end

--- a/spec/v4/prefecture_spec.rb
+++ b/spec/v4/prefecture_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/prefecture'
+
+::RSpec.describe(::JapaneseAddressParser::V4::Prefecture) do
+  describe '.from_metadata' do
+    context 'with nil (prefecture not detected)' do
+      it 'returns nil' do
+        expect(described_class.from_metadata(nil)).to(be_nil)
+      end
+    end
+
+    context 'with a metadata hash (Symbol keys, point [lng, lat])' do
+      subject(:prefecture) { described_class.from_metadata(hash) }
+
+      let(:hash) do
+        { code: 13, pref: '東京都', pref_k: 'トウキョウト', pref_r: 'Tokyo', point: [139.691722, 35.689501] }
+      end
+
+      it 'maps name/code/kana/romaji' do
+        expect(prefecture.name).to(eq('東京都'))
+        expect(prefecture.code).to(eq(13))
+        expect(prefecture.name_kana).to(eq('トウキョウト'))
+        expect(prefecture.name_romaji).to(eq('Tokyo'))
+      end
+
+      it 'builds a level-1 representative point with lat/lng swapped from [lng, lat]' do
+        expect(prefecture.point.lat).to(eq(35.689501))
+        expect(prefecture.point.lng).to(eq(139.691722))
+        expect(prefecture.point.level).to(eq(1))
+      end
+    end
+  end
+
+  describe '#to_h' do
+    it 'deep-converts the nested point' do
+      prefecture = described_class.from_metadata({ code: 13, pref: '東京都', pref_k: 'トウキョウト', pref_r: 'Tokyo', point: [139.691722, 35.689501] })
+
+      expect(prefecture.to_h).to(eq(name: '東京都', code: 13, name_kana: 'トウキョウト', name_romaji: 'Tokyo', point: { lat: 35.689501, lng: 139.691722, level: 1 }))
+    end
+  end
+end

--- a/spec/v4/town_spec.rb
+++ b/spec/v4/town_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/town'
+
+::RSpec.describe(::JapaneseAddressParser::V4::Town) do
+  describe '.from_metadata' do
+    context 'with nil (town not detected)' do
+      it 'returns nil' do
+        expect(described_class.from_metadata(nil)).to(be_nil)
+      end
+    end
+
+    context 'with a chome (point present)' do
+      subject(:town) { described_class.from_metadata(hash) }
+
+      let(:hash) do
+        {
+          machiaza_id: '0001001',
+          oaza_cho: '大豆戸町',
+          oaza_cho_k: 'マメドチョウ',
+          oaza_cho_r: 'Mamedocho',
+          chome: '一丁目',
+          chome_n: 1,
+          koaza: nil,
+          rsdt: nil,
+          point: [139.631, 35.508]
+        }
+      end
+
+      it 'composes name (machiAzaName) and keeps both chome and chome_n' do
+        expect(town.name).to(eq('大豆戸町一丁目'))
+        expect(town.machiaza_id).to(eq('0001001'))
+        expect(town.chome).to(eq('一丁目'))
+        expect(town.chome_n).to(eq(1))
+        expect(town.koaza).to(be_nil)
+      end
+
+      it 'builds a level-3 representative point with lat/lng swapped from [lng, lat]' do
+        expect(town.point.lat).to(eq(35.508))
+        expect(town.point.lng).to(eq(139.631))
+        expect(town.point.level).to(eq(3))
+      end
+    end
+
+    context 'without a point' do
+      subject(:town) { described_class.from_metadata(hash) }
+
+      let(:hash) do
+        { machiaza_id: '0002000', oaza_cho: '本町', chome: nil, chome_n: nil, koaza: nil, point: nil }
+      end
+
+      it 'leaves point nil' do
+        expect(town.name).to(eq('本町'))
+        expect(town.point).to(be_nil)
+      end
+    end
+  end
+
+  describe '#to_h' do
+    it 'deep-converts the nested point' do
+      town = described_class.from_metadata({ machiaza_id: '0001001', oaza_cho: '大豆戸町', chome: '一丁目', chome_n: 1, koaza: nil, point: [139.631, 35.508] })
+
+      expect(town.to_h).to(eq(name: '大豆戸町一丁目', machiaza_id: '0001001', chome: '一丁目', chome_n: 1, koaza: nil, point: { lat: 35.508, lng: 139.631, level: 3 }))
+    end
+  end
+end


### PR DESCRIPTION
## 概要

M6（公開 API & リッチ VO）の **PR1**。内部 `NormalizeResult`（M5）を包む Ruby 独自のリッチ Value Object 層を追加する。公開エントリ `V4.call/.call!` は PR2 で追加する。

## 変更点

- `Address` / `Prefecture` / `City` / `Town`（`::Data.define`）を追加。`metadata`（`prefecture`=Hash / `city`=`SingleCity` VO / `machi_aza`=Hash）から `name`・`code`・カナ・ローマ字・`point` を供給。
- `Address.from_normalize_result` で `NormalizeResult` → `Address` 変換。`#to_h` はネスト VO・座標も含めて Hash 化（`metadata` は生データ逃がし道として shallow）。
- 未マッチ（level 0）は失敗ではなく、各ネスト VO が `nil` の `Address` を返す（JS 忠実）。
- 座標構築の重複を解消するため `NormalizeResultPoint.from_lng_lat([lng, lat], level:)` ファクトリを追加（`Prefecture`/`Town` が共有）。上流 `types.ts` の `*ToResultPoint` は逐語移植のまま温存。
- RBS（`sig/v4/address.rbs` 追加、`to_h`/`from_lng_lat` 宣言）。

## 確定した設計判断（`docs/rearchitecture.md` §5.2 更新）

- `Town` は `chome`（"一丁目" 等の文字列）と `chome_n`（整数）の**両方**を持つ（JS `SingleMachiAza` の情報量に揃える）。
- 各 VO の `point` は `NormalizeResultPoint(lat, lng, level)`（§1-4 の忠実表現と一貫）。
- 公開エントリは M9 まで `JapaneseAddressParser::V4.call/.call!`（旧トップレベル `call` と並存）、M9 で `JapaneseAddressParser.call` へ昇格。

## 検証

- `bundle exec rspec spec/v4/` … 171 examples, 0 failures
- `bundle exec rubocop`（v4/sig）… no offenses
- `bundle exec steep check` … No type error

base: `rearchitecture`