### PR TITLE
feat(v4): add public entry point and complete M6

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,7 @@ Metrics/ModuleLength:
 Lint/ConstantResolution:
   Exclude:
     - lib/japanese_address_parser/v4/**/*.rb
+    - lib/japanese_address_parser/v4.rb
 
 Style/InlineComment:
   Exclude:

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -11,7 +11,7 @@
 - [x] **M3** 設定 & データアクセス層（config / fetcher）
 - [x] **M4** cacheRegexes（level 3 まで）
 - [x] **M5** normalize 本体（level 0–3）
-- [ ] **M6** 公開 API & リッチ VO
+- [x] **M6** 公開 API & リッチ VO
 - [ ] **M7** テストスイート移植
 - [ ] **M8** level 8（rsdt / chiban）
 - [ ] **M9** 旧実装撤去 & 仕上げ

--- a/lib/japanese_address_parser/v4.rb
+++ b/lib/japanese_address_parser/v4.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Public entry point for the v4 normalize API (M6).
+# Ruby-original surface over the faithful V4::Normalize core (working_agreement §1-7 / rearchitecture §5.1, §5.3):
+#   - 常に Address を返す（未マッチは level 0 の Address。未マッチは失敗ではない）。
+#   - fetch（remote/file）失敗時のみ、call は nil・call! は NormalizeError を raise する。
+# 旧トップレベル JapaneseAddressParser.call とは V4 名前空間で並存し、M9 で昇格する。
+
+require 'net/http'
+require 'json'
+require 'japanese_address_parser/exceptions'
+require 'japanese_address_parser/v4/normalize'
+require 'japanese_address_parser/v4/address'
+
+module JapaneseAddressParser
+  # v4 公開エントリ。config.rb で定義済みの V4 名前空間を再オープンし、call/call! を追加する。
+  module V4
+    # JS: defaultOption = { level: 8 }
+    DEFAULT_LEVEL = 8
+    public_constant :DEFAULT_LEVEL
+
+    module_function
+
+    # 住所文字列を正規化して Address を返す。fetch 失敗時は nil。
+    def call(address, level: DEFAULT_LEVEL)
+      call!(address, level: level)
+    rescue ::JapaneseAddressParser::NormalizeError
+      nil
+    end
+
+    # 住所文字列を正規化して Address を返す。fetch 失敗時は NormalizeError を raise。
+    #
+    # rescue で握るのは唯一の I/O 境界 Fetcher が投げ得る「fetch 失敗」のみ（working_agreement §1-7）:
+    #   SocketError       — DNS 解決不可・接続不可
+    #   SystemCallError   — Errno::*（接続拒否、file:// のファイル無し/権限不足 等）
+    #   Net::OpenTimeout / Net::ReadTimeout — タイムアウト
+    #   JSON::ParserError — 取得したボディが不正な JSON（配信データの取得失敗）。
+    #                       JSON 解析は Fetcher 経由で取得したデータに対してのみ行われるため、fetch 失敗として扱う。
+    # 設定/プログラマエラー（ArgumentError=未知 URL スキーム / NotImplementedError=M8）は
+    # 意図的に握らず、そのまま伝播させる。
+    def call!(address, level: DEFAULT_LEVEL)
+      Address.from_normalize_result(Normalize.call(address, level: level))
+    rescue ::SocketError, ::SystemCallError, ::Net::OpenTimeout, ::Net::ReadTimeout, ::JSON::ParserError => e
+      raise(::JapaneseAddressParser::NormalizeError, "failed to fetch address data: #{e.message}")
+    end
+  end
+end

--- a/lib/japanese_address_parser/v4/normalize_result_point.rb
+++ b/lib/japanese_address_parser/v4/normalize_result_point.rb
@@ -18,6 +18,17 @@ module JapaneseAddressParser
 
           new(lat: point[1], lng: point[0], level: level)
         end
+
+        # JS: isNormalizeResultPoint(obj) — 任意の値が NormalizeResultPoint の形か検証する type guard。
+        # JS は object のプロパティ存在＋数値型を見る。Ruby では lat/lng/level に応答し、それらが
+        # Numeric かつ level が 1/2/3/8 のいずれか、で判定する（JS↔Ruby のオブジェクトモデル差のため
+        # Hash は対象外＝working_agreement §3-4。挙動は spec に固定する）。
+        def self.normalize_result_point?(obj)
+          return false unless obj.respond_to?(:lat) && obj.respond_to?(:lng) && obj.respond_to?(:level)
+          return false unless obj.lat.is_a?(::Numeric) && obj.lng.is_a?(::Numeric) && obj.level.is_a?(::Numeric)
+
+          [1, 2, 3, 8].include?(obj.level) # JS: validLevels = [1, 2, 3, 8]
+        end
       end
     public_constant :NormalizeResultPoint
 

--- a/sig/v4/api.rbs
+++ b/sig/v4/api.rbs
@@ -1,0 +1,11 @@
+# Interim signature for the v4.0.0 public entry point (M6).
+# The full RBS overhaul happens in M9.
+
+module JapaneseAddressParser
+  module V4
+    DEFAULT_LEVEL: Integer
+
+    def self.call: (String address, ?level: Integer) -> Address?
+    def self.call!: (String address, ?level: Integer) -> Address
+  end
+end

--- a/sig/v4/normalize_result_point.rbs
+++ b/sig/v4/normalize_result_point.rbs
@@ -10,6 +10,7 @@ module JapaneseAddressParser
 
       def self.new: (lat: Float, lng: Float, level: Integer) -> instance
       def self.from_lng_lat: ([Float, Float]? point, level: Integer) -> NormalizeResultPoint?
+      def self.normalize_result_point?: (untyped obj) -> bool
       def to_h: () -> Hash[Symbol, untyped]
     end
 

--- a/spec/v4/api_spec.rb
+++ b/spec/v4/api_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4'
+
+# 公開エントリ V4.call / V4.call!（M6）。
+# happy path と未マッチは上流同様ライブ CDN を叩く（working_agreement §1-8、:upstream_port）。
+# fetch 失敗の契約（call=nil / call!=raise）は、唯一の I/O 境界である Normalize.call を
+# スタブして決定的に検証する（モジュールキャッシュ・ネットワークに依存させない）。
+::RSpec.describe(::JapaneseAddressParser::V4) do
+  describe '.call', :upstream_port do
+    let(:address) { '神奈川県横浜市港北区大豆戸町１７番地１１' }
+
+    it 'returns a rich Address with nested value objects' do
+      result = described_class.call(address, level: 3)
+
+      expect(result).to(be_a(::JapaneseAddressParser::V4::Address))
+      expect(result.full_address).to(eq(address))
+      expect(result.prefecture.name).to(eq('神奈川県'))
+      expect(result.city.name).to(eq('横浜市港北区'))
+      expect(result.town.name).to(eq('大豆戸町'))
+      expect(result.level).to(eq(3))
+    end
+
+    it 'returns a level-0 Address (not nil) when nothing matches — unmatched is not a failure' do
+      result = described_class.call('あいうえお')
+
+      expect(result).to(be_a(::JapaneseAddressParser::V4::Address))
+      expect(result.prefecture).to(be_nil)
+      expect(result.city).to(be_nil)
+      expect(result.town).to(be_nil)
+      expect(result.level).to(eq(0))
+    end
+
+    it 'defaults to level 8 (capped at level 3 until M8)' do
+      expect(described_class.call(address).level).to(eq(3))
+    end
+  end
+
+  describe 'fetch-failure contract (stubbed I/O boundary)' do
+    let(:address) { '神奈川県横浜市港北区大豆戸町１７番地１１' }
+
+    # V4.call! が「fetch 失敗」として握る代表例外（lib/japanese_address_parser/v4.rb の rescue 一覧に対応）。
+    # Errno::ECONNREFUSED は SystemCallError のサブクラスを握れることの確認も兼ねる。
+    [::SocketError, ::Errno::ECONNREFUSED, ::Net::OpenTimeout, ::Net::ReadTimeout, ::JSON::ParserError].each do |error_class|
+      context "when the fetch raises #{error_class}" do
+        before { allow(::JapaneseAddressParser::V4::Normalize).to(receive(:call).and_raise(error_class)) }
+
+        it '.call returns nil' do
+          expect(described_class.call(address)).to(be_nil)
+        end
+
+        it '.call! raises NormalizeError' do
+          expect { described_class.call!(address) }
+            .to(raise_error(::JapaneseAddressParser::NormalizeError))
+        end
+      end
+    end
+
+    context 'when the fetch raises a non-fetch error (programmer/config error)' do
+      # 未知 URL スキーム等の設定/プログラマエラーは握り潰さず伝播させる（§1-7「fetch 失敗時のみ」）。
+      before { allow(::JapaneseAddressParser::V4::Normalize).to(receive(:call).and_raise(::ArgumentError, 'Unknown URL schema: ftp:')) }
+
+      it '.call! propagates the original error (not NormalizeError)' do
+        expect { described_class.call!(address) }
+          .to(raise_error(::ArgumentError, /Unknown URL schema/))
+      end
+
+      it '.call also propagates it (only NormalizeError is rescued to nil)' do
+        expect { described_class.call(address) }
+          .to(raise_error(::ArgumentError))
+      end
+    end
+  end
+end

--- a/spec/v4/normalize_result_point_factory_spec.rb
+++ b/spec/v4/normalize_result_point_factory_spec.rb
@@ -16,4 +16,29 @@ require 'japanese_address_parser/v4/normalize_result_point'
       expect(described_class.from_lng_lat(nil, level: 3)).to(be_nil)
     end
   end
+
+  describe '.normalize_result_point?' do
+    it 'is true for a point with numeric lat/lng and a valid level' do
+      [1, 2, 3, 8].each do |level|
+        expect(described_class.normalize_result_point?(described_class.new(lat: 35.0, lng: 139.0, level: level))).to(be(true))
+      end
+    end
+
+    it 'is false for an invalid level' do
+      expect(described_class.normalize_result_point?(described_class.new(lat: 35.0, lng: 139.0, level: 4))).to(be(false))
+      expect(described_class.normalize_result_point?(described_class.new(lat: 35.0, lng: 139.0, level: 0))).to(be(false))
+    end
+
+    it 'is false for objects that do not respond to lat/lng/level' do
+      expect(described_class.normalize_result_point?(nil)).to(be(false))
+      expect(described_class.normalize_result_point?('35.0')).to(be(false))
+      # JS↔Ruby のオブジェクトモデル差: JS はプロパティで見るが Ruby はメソッド応答で見るため
+      # Hash（[]アクセス）は対象外（working_agreement §3-4）。
+      expect(described_class.normalize_result_point?({ lat: 35.0, lng: 139.0, level: 3 })).to(be(false))
+    end
+
+    it 'is false when a coordinate is non-numeric' do
+      expect(described_class.normalize_result_point?(described_class.new(lat: '35.0', lng: 139.0, level: 3))).to(be(false))
+    end
+  end
 end


### PR DESCRIPTION
## 概要

M6（公開 API & リッチ VO）の **PR2**。これで **M6 完了**。PR1 のリッチ VO 層の上に、Ruby 独自の公開エントリを載せる。

## 変更点

- **`JapaneseAddressParser::V4.call/.call!`**（`lib/japanese_address_parser/v4.rb`）
  - `V4::Normalize.call`（M5）→ `Address.from_normalize_result`（M6 PR1）でラップ。既定 `level: 8`。
  - **未マッチは失敗ではない**：都道府県すら判別できなくても level 0 の `Address` を返す（JS 忠実 §1-7）。
  - **fetch 失敗時のみ** `call` は nil・`call!` は `NormalizeError`。握る例外は唯一の I/O 境界 Fetcher が投げ得るもの（`SocketError` / `SystemCallError` / `Net::OpenTimeout` / `Net::ReadTimeout` / `JSON::ParserError`）に限定。設定/プログラマエラー（未知 URL スキームの `ArgumentError`、M8 の `NotImplementedError`）は握らず伝播。
  - 旧トップレベル `JapaneseAddressParser.call` とは V4 名前空間で並存（M9 で昇格）。
- **`isNormalizeResultPoint` 移植**：`NormalizeResultPoint.normalize_result_point?(obj)`（types.ts の type guard を逐語移植。lat/lng/level が Numeric かつ level ∈ [1,2,3,8]。JS↔Ruby のオブジェクトモデル差で Hash は対象外＝§3-4、spec で固定）。
- RBS（`sig/v4/api.rbs` 追加、predicate 宣言）、`docs/milestones.md` の M6 を `[x]` に。

## テスト方針

- happy path / 未マッチ=level0 は上流同様ライブ CDN（`:upstream_port`）。
- **fetch 失敗の契約は `Normalize.call` をスタブして決定的に検証**（モジュールキャッシュ・ネットワークに依存させない）。非 fetch 例外が伝播することも固定。

## 検証

- `bundle exec rspec spec/v4/` … 190 examples, 0 failures
- `bundle exec rubocop`（v4/sig）… no offenses
- `bundle exec steep check` … No type error

base: \`rearchitecture\`