### PR TITLE
test(v4): port main.test.ts and add close-to matcher (M7 PR1)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,6 +80,13 @@ RSpec/FilePath:
   Exclude:
     - spec/v4/**/*_spec.rb
 
+# v4 移植スイートでは level 8 が必要なケースを M8 まで pending で枠だけ確保する（M7 DoD）。
+# インライン disable は禁止（Style/DisableCopsWithinSourceCodeDirective）のため、pending を持つ
+# ファイルを個別に除外する。M8 で pending が外れたら該当エントリも削除する。
+RSpec/Pending:
+  Exclude:
+    - spec/v4/main_spec.rb
+
 # MITなのでファイルの著作権は記載しない。
 Style/Copyright:
   Enabled: false
@@ -101,6 +108,7 @@ Style/StringHashKeys:
     - spec/v4/data/single_prefecture_spec.rb
     - spec/v4/city_spec.rb
     - spec/v4/address_spec.rb
+    - spec/v4/match_close_to_spec.rb
     - spec/v4/data/single_machi_aza_spec.rb
     - spec/v4/data/single_rsdt_spec.rb
     - spec/v4/data/single_chiban_spec.rb

--- a/spec/v4/main_spec.rb
+++ b/spec/v4/main_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+# Port of test/main/main.test.ts (basic tests)。上流同様ライブ CDN を叩く（working_agreement §1-8）。
+# level 8 が必要なケースは M8 まで pending（DoD）。比較は assertMatchCloseTo 相当の match_close_to。
+
+require 'japanese_address_parser/v4'
+require_relative 'support/match_close_to'
+
+::RSpec.describe(::JapaneseAddressParser::V4, :upstream_port) do
+  subject(:normalize) { described_class }
+
+  describe 'level resolution for 神奈川県横浜市港北区大豆戸町１７番地１１' do
+    let(:address) { '神奈川県横浜市港北区大豆戸町１７番地１１' }
+
+    it 'resolves to level 1 when level: 1' do
+      expect(normalize.call(address, level: 1)).to(match_close_to(pref: '神奈川県', level: 1))
+    end
+
+    it 'resolves to level 2 when level: 2' do
+      expect(normalize.call(address, level: 2)).to(match_close_to(pref: '神奈川県', city: '横浜市港北区', level: 2))
+    end
+
+    it 'resolves to level 3 when level: 3' do
+      expect(normalize.call(address, level: 3)).to(match_close_to(pref: '神奈川県', city: '横浜市港北区', town: '大豆戸町', other: '17-11', level: 3))
+    end
+  end
+
+  it 'gets level 2 with 神奈川県横浜市港北区' do
+    expect(normalize.call('神奈川県横浜市港北区', level: 3)).to(match_close_to(pref: '神奈川県', city: '横浜市港北区', level: 2))
+  end
+
+  it 'gets level 1 with 神奈川県' do
+    expect(normalize.call('神奈川県', level: 3)).to(match_close_to(pref: '神奈川県', level: 1))
+  end
+
+  it 'gets level 1 with 神奈川県あいうえお市' do
+    expect(normalize.call('神奈川県あいうえお市')).to(match_close_to(pref: '神奈川県', level: 1))
+  end
+
+  it 'gets level 2 with 東京都港区あいうえお' do
+    expect(normalize.call('東京都港区あいうえお')).to(match_close_to(pref: '東京都', city: '港区', level: 2))
+  end
+
+  it 'gets level 0 with あいうえお' do
+    expect(normalize.call('あいうえお')).to(match_close_to(other: 'あいうえお', level: 0))
+  end
+
+  # level 8（rsdt）ケースは M8 まで pending で枠を確保する（M7 DoD）。M8 で外れたら RSpec が FIXED を報告する。
+  # （RSpec/Pending はインライン disable 不可のため .rubocop.yml でこのファイルを除外している。）
+  describe '東京都江東区豊洲一丁目2-27 のパターンテスト (level 8 — pending until M8)' do
+    addresses = ['東京都江東区豊洲1丁目2-27', '東京都江東区豊洲 1丁目2-27', '東京都江東区豊洲 1-2-27', '東京都 江東区 豊洲 1-2-27', '東京都江東区豊洲 １ー２ー２７', '東京都江東区豊洲 一丁目2-27', '江東区豊洲 一丁目2-27']
+    addresses.each do |address|
+      it address do
+        pending('level 8 (rsdt) — enabled in M8')
+        expect(normalize.call(address)).to(match_close_to(pref: '東京都', city: '江東区', town: '豊洲一丁目', addr: '2-27', level: 8, point: { lat: 35.661166758, lng: 139.793685144, level: 8 }))
+      end
+    end
+  end
+
+  describe '丁目以降の半角・全角・漢数字の番地正規化' do
+    it 'normalizes イ-prefixed addr remainder' do
+      expect(normalize.call('東京都町田市木曽東四丁目１４ーイ２２ ジオロニアマンション')).to(match_close_to(other: '14-イ22 ジオロニアマンション'))
+    end
+
+    it 'normalizes full-width alnum addr remainder' do
+      expect(normalize.call('東京都町田市木曽東四丁目１４ーＡ２２ ジオロニアマンション')).to(match_close_to(other: '14-A22 ジオロニアマンション'))
+    end
+
+    it 'normalizes kanji-numeral addr remainder' do
+      expect(normalize.call('東京都町田市木曽東四丁目一四━Ａ二二 ジオロニアマンション')).to(match_close_to(other: '14-A22 ジオロニアマンション'))
+    end
+
+    it 'resolves a kanji-numeral chome (東京都江東区豊洲 四-2-27)' do
+      expect(normalize.call('東京都江東区豊洲 四-2-27')).to(match_close_to(town: '豊洲四丁目'))
+    end
+  end
+
+  # 上流 main.test.ts の対になる level 8 パターン（豊洲と同じく M8 まで pending）。
+  # 上流の期待 point.level は 8 ではなく 2（rsdt 座標が無く市の代表点へフォールバックする上流クセ）をそのまま移植。
+  describe '石川県七尾市藤橋町亥45番地1 のパターンテスト (level 8 — pending until M8)' do
+    addresses = ['石川県七尾市藤橋町亥45番地1', '石川県七尾市藤橋町亥四十五番地1', '石川県七尾市藤橋町 亥 四十五番地1', '石川県七尾市藤橋町 亥 45-1', '七尾市藤橋町 亥 45-1']
+    addresses.each do |address|
+      it address do
+        pending('level 8 (rsdt) — enabled in M8')
+        expect(normalize.call(address)).to(match_close_to(pref: '石川県', city: '七尾市', town: '藤橋町亥', addr: '45-1', level: 8, point: { lat: 37.043108, lng: 136.967296, level: 2 }))
+      end
+    end
+  end
+
+  it 'handles unicode (NFKD) normalization' do
+    address = '茨城県つくば市筑穂１丁目１０−４'.unicode_normalize(:nfkd)
+    expect(normalize.call(address).city.name).to(eq('つくば市'))
+  end
+
+  it 'does not convert kanji numerals in the remainder when the town name is undetermined' do
+    result = normalize.call('北海道滝川市一の坂町西')
+    expect(result).to(match_close_to(level: 2, other: '一の坂町西'))
+    expect(result.town).to(be_nil)
+  end
+
+  describe '丁目の数字だけあるときは「一丁目」まで補充する' do
+    it 'fills 小石川1 to 小石川一丁目' do
+      expect(normalize.call('東京都文京区小石川1')).to(match_close_to(town: '小石川一丁目', other: ''))
+    end
+
+    it 'fills 小石川1ビル名 to 小石川一丁目 with the remainder kept' do
+      expect(normalize.call('東京都文京区小石川1ビル名')).to(match_close_to(town: '小石川一丁目', other: 'ビル名'))
+    end
+  end
+
+  describe '旧漢字対応' do
+    [
+      { label: '亞 -> 亜', addresses: %w[宮城県大崎市古川大崎東亞 宮城県大崎市古川大崎東亜], expected: { town: '古川大崎字東亜', level: 3 } },
+      { label: '澤 -> 沢', addresses: %w[東京都西多摩郡奥多摩町海沢 東京都西多摩郡奥多摩町海澤], expected: { town: '海澤', level: 3 } },
+      { label: '麩 -> 麸', addresses: %w[愛知県津島市池麩町 愛知県津島市池麸町], expected: { town: '池麸町', level: 3 } },
+      { label: '驒 -> 騨', addresses: %w[岐阜県飛驒市 岐阜県飛騨市], expected: { city: '飛騨市', level: 2 } }
+    ].each do |data|
+      it data[:label] do
+        data[:addresses].each do |address|
+          expect(normalize.call(address)).to(match_close_to(**data[:expected]))
+        end
+      end
+    end
+  end
+
+  it '柿碕町|柿さき町' do
+    %w[愛知県安城市柿さき町 愛知県安城市柿碕町].each do |address|
+      expect(normalize.call(address)).to(match_close_to(town: '柿碕町', level: 3))
+    end
+  end
+
+  describe '漢数字の小字のケース' do
+    it '愛知県豊田市西丹波町三五十' do
+      expect(normalize.call('愛知県豊田市西丹波町三五十')).to(match_close_to(town: '西丹波町', other: '三五十', level: 3))
+    end
+
+    it '広島県府中市栗柄町名字八五十2459（小字以降は無視される）' do
+      expect(normalize.call('広島県府中市栗柄町名字八五十2459')).to(match_close_to(town: '栗柄町', other: '名字八五十2459', level: 3))
+    end
+  end
+end

--- a/spec/v4/match_close_to_spec.rb
+++ b/spec/v4/match_close_to_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'japanese_address_parser/v4/address'
+require 'japanese_address_parser/v4/normalize_result'
+require 'japanese_address_parser/v4/normalize_result_point'
+require 'japanese_address_parser/v4/data/single_city'
+require_relative 'support/match_close_to'
+
+# match_close_to マッチャ自体のユニットテスト（ネットワーク不要）。
+# ライブ CDN を叩く移植スイート（main_spec 等）と、PR2 の addresses.csv 全件 diff が依存する基盤。
+# 近似比較・部分一致・未知キーガードをここで決定的に固定する（point 近似比較パスは level 8 が
+# pending の間、ここだけが実際に exercise する）。
+::RSpec.describe(::MatchCloseToHelper) do
+  def build_address(pref: nil, city: nil, town: nil, other: '', point: nil, level: 0)
+    prefecture = pref && { code: 13, pref: pref, pref_k: 'X', pref_r: 'X', point: [139.0, 35.0] }
+    single_city = city && ::JapaneseAddressParser::V4::Data::SingleCity.from_json('code' => 1, 'city' => city, 'city_k' => 'X', 'city_r' => 'X', 'point' => [139.0, 35.0])
+    machi_aza = town && { machiaza_id: '1', oaza_cho: town, chome: nil, chome_n: nil, koaza: nil, point: nil }
+    metadata = ::JapaneseAddressParser::V4::NormalizeResultMetadata.new(input: 'x', prefecture: prefecture, city: single_city, machi_aza: machi_aza, chiban: nil, rsdt: nil)
+    result = ::JapaneseAddressParser::V4::NormalizeResult.new(pref: pref, city: city, town: town, addr: nil, other: other, point: point, level: level, metadata: metadata)
+    ::JapaneseAddressParser::V4::Address.from_normalize_result(result)
+  end
+
+  def point(lat, lng, level)
+    ::JapaneseAddressParser::V4::NormalizeResultPoint.new(lat: lat, lng: lng, level: level)
+  end
+
+  it 'matches when the specified scalar fields are equal (and ignores unspecified fields)' do
+    address = build_address(pref: '東京都', city: '渋谷区', town: '道玄坂', other: 'x', level: 3)
+    expect(address).to(match_close_to(pref: '東京都', level: 3))
+  end
+
+  it 'does not match when a specified scalar field differs' do
+    address = build_address(pref: '東京都', level: 1)
+    expect(address).not_to(match_close_to(pref: '大阪府', level: 1))
+  end
+
+  describe 'point comparison' do
+    let(:address) { build_address(level: 3, point: point(35.0, 139.0, 3)) }
+
+    # 既定 precision=2 → 許容差 0.5*10**-2 = 0.005（包含）。0.003 は通り、0.01 は外れる
+    # （3 桁=0.0005 だったら 0.003 で外れるはずなので、既定が 2 であることを固定する）。
+    it 'matches coordinates within the default (precision 2) tolerance' do
+      expect(address).to(match_close_to(point: { lat: 35.003, lng: 139.003, level: 3 }))
+    end
+
+    it 'does not match coordinates outside the tolerance' do
+      expect(address).not_to(match_close_to(point: { lat: 35.01, lng: 139.0, level: 3 }))
+    end
+
+    it 'does not match when the point level differs (strict on level)' do
+      expect(address).not_to(match_close_to(point: { lat: 35.0, lng: 139.0, level: 8 }))
+    end
+
+    it 'does not match when a point is expected but absent' do
+      expect(build_address(level: 0)).not_to(match_close_to(point: { lat: 35.0, lng: 139.0, level: 3 }))
+    end
+  end
+
+  it 'raises on an unknown expected key rather than silently comparing nil' do
+    address = build_address(pref: '東京都', level: 1)
+    expect { expect(address).to(match_close_to(full_address: 'x')) }
+      .to(raise_error(::ArgumentError, /unknown expected key/))
+  end
+end

--- a/spec/v4/support/match_close_to.rb
+++ b/spec/v4/support/match_close_to.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Port of test/helpers.ts `assertMatchCloseTo`（`jest-matcher-deep-close-to` の `toMatchCloseTo`）。
+# 上流テストは NormalizeResult を「部分一致（expected に在るキーのみ）＋数値は近似一致」で検証する。
+# v4 公開 API は Address VO を返すため、期待値は上流 NormalizeResult のキー名
+# （pref/city/town/addr/other/level/point）で渡し、Address のフィールドへマッピングして比較する。
+#
+# 近似許容差は jest-matcher-deep-close-to の cmpNumber を移植:
+#   |a - b| <= calculatePrecision(p)、calculatePrecision(p) = 0.5 * 10**(-p)。比較は `<=`（包含）。
+# decimals 既定は同ライブラリの既定（precision = 2）に合わせる。
+
+module MatchCloseToHelper
+  DEFAULT_DECIMALS = 2
+  public_constant :DEFAULT_DECIMALS
+
+  module_function
+
+  # Address を上流 NormalizeResult のキー名（pref/city/town/...）へ写した Hash。
+  def normalized_fields(address)
+    {
+      pref: address.prefecture&.name,
+      city: address.city&.name,
+      town: address.town&.name,
+      addr: address.addr,
+      other: address.other,
+      level: address.level,
+      point: address.point
+    }
+  end
+
+  # jest-matcher-deep-close-to の cmpNumber を移植: |a - b| <= 0.5 * 10**(-decimals)。
+  # 比較は `<=`（包含。上流 calculatePrecision と同値で、RSpec の be_within(δ).of と同じ境界）。
+  def close?(actual, expected, decimals)
+    return false unless actual.is_a?(::Numeric) && expected.is_a?(::Numeric)
+
+    (actual - expected).abs <= (0.5 * (10**-decimals))
+  end
+
+  # 不一致キーの説明文配列を返す（空なら一致）。
+  # PR2（addresses.csv 全件）・PR3 でも共有するため、未知の期待キーは黙って nil 比較せず明示的に落とす。
+  def mismatches(address, expected, decimals)
+    actual = normalized_fields(address)
+    unknown = expected.keys - actual.keys
+    raise(::ArgumentError, "unknown expected key(s): #{unknown.join(', ')}") unless unknown.empty?
+
+    expected.filter_map do |key, exp|
+      key == :point ? point_mismatch(actual[key], exp, decimals) : scalar_mismatch(key, actual[key], exp)
+    end
+  end
+
+  def scalar_mismatch(key, actual, expected)
+    return if actual == expected
+
+    "#{key}: expected #{expected.inspect}, got #{actual.inspect}"
+  end
+
+  # point は lat/lng を近似比較、level は厳密比較する。
+  def point_mismatch(actual, expected, decimals)
+    return "point: expected #{expected.inspect}, got nil" if actual.nil?
+
+    errors = []
+    errors << "lat #{actual.lat} !~ #{expected[:lat]}" unless close?(actual.lat, expected[:lat], decimals)
+    errors << "lng #{actual.lng} !~ #{expected[:lng]}" unless close?(actual.lng, expected[:lng], decimals)
+    # 上流は level も close-to で見るが、level は整数のため厳密比較で等価（0.0005 未満 ⇔ 同値）。
+    errors << "level #{actual.level} != #{expected[:level]}" unless actual.level == expected[:level]
+    errors.empty? ? nil : "point: #{errors.join(', ')}"
+  end
+end
+
+# 使い方: expect(::JapaneseAddressParser::V4.call(addr)).to(match_close_to(pref: '神奈川県', level: 1))
+::RSpec::Matchers.define(:match_close_to) do |expected, decimals = ::MatchCloseToHelper::DEFAULT_DECIMALS|
+  match do |address|
+    ::MatchCloseToHelper.mismatches(address, expected, decimals).empty?
+  end
+
+  failure_message do |address|
+    mismatches = ::MatchCloseToHelper.mismatches(address, expected, decimals)
+    "expected the normalized address to match (numbers close to #{decimals} decimals), but:\n" +
+      mismatches.map { |m| "  - #{m}" }
+                .join("\n")
+  end
+end


### PR DESCRIPTION
## 概要

M7（テストスイート移植）の **PR1**。上流 `test/main/main.test.ts`（basic tests）を移植し、その基盤となる近似一致マッチャを追加する。`addresses.csv` 全件（PR2）と `filesystem`/`metadata`（PR3）はこのマッチャを再利用する。

## 変更点

- **`spec/v4/support/match_close_to.rb`** — `assertMatchCloseTo`（`jest-matcher-deep-close-to`）の逐語移植マッチャ。
  - 部分一致（`expected` に在るキーのみ検証）＋座標の近似比較。
  - 上流 `NormalizeResult` のキー名（`pref`/`city`/`town`/`addr`/`other`/`level`/`point`）→ `Address` VO へマッピングし、上流の期待値をそのまま渡せる。
  - 近似は上流 `cmpNumber` を実証移植：`|a-b| <= 0.5*10**(-precision)`、**precision 既定 2**、比較は **`<=`**（上流ソースを取得して確認）。
  - 未知の期待キーは黙って nil 比較せず例外（PR2/PR3 の共有基盤としての堅牢化）。
- **`spec/v4/main_spec.rb`** — `main.test.ts` basic tests を全ケース移植（`V4.call` 対象）。level 0–3 は有効、**level 8（豊洲・七尾パターン）は M8 まで `pending`**（DoD）。
- **`spec/v4/match_close_to_spec.rb`** — マッチャ自体のオフライン単体テスト（近似・部分一致・未知キーガード。level8 が pending の間、座標近似パスを実際に exercise する）。
- **`.rubocop.yml`** — `RSpec/Pending` を `main_spec.rb` のみ除外（インライン disable 禁止のため・M8 で削除）、`match_close_to_spec.rb` を `StringHashKeys` 除外（`from_json` 文字列キー）。

## テスト方針

- `main_spec` は上流同様ライブ CDN を叩く（`:upstream_port`）。
- fidelity 確認済み：上流 `main.test.ts` の全 case-group を網羅（七尾パターン含む）。マッチャは上流 `jest-matcher-deep-close-to` の既定 precision=2・`<=` 境界に一致。

## 検証

- `bundle exec rspec spec/v4/` … 232 examples, 0 failures, **12 pending**（level 8）
- `bundle exec rubocop`（v4/sig）… no offenses
- `bundle exec steep check` … No type error

base: \`rearchitecture\`