### PR TITLE
feat(v4): implement rsdt/chiban subresource fetch (M8 PR1)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -119,6 +119,7 @@ Style/StringHashKeys:
     - spec/v4/city_spec.rb
     - spec/v4/address_spec.rb
     - spec/v4/match_close_to_spec.rb
+    - spec/v4/cache_regexes_subresource_spec.rb
     - spec/v4/data/single_machi_aza_spec.rb
     - spec/v4/data/single_rsdt_spec.rb
     - spec/v4/data/single_chiban_spec.rb

--- a/lib/japanese_address_parser/v4/cache_regexes.rb
+++ b/lib/japanese_address_parser/v4/cache_regexes.rb
@@ -4,6 +4,7 @@
 # Upstream: @geolonia/normalize-japanese-addresses v3.1.3
 #   level 0-3 部分のみ。rsdt/chiban（getRsdt/getChiban/fetchSubresource/parseSubresource）は M8 で実装する。
 
+require 'csv'
 require 'set'
 require 'lru_redux'
 require 'japanese_address_parser/v4/config'
@@ -13,6 +14,8 @@ require 'japanese_address_parser/v4/kan2num'
 require 'japanese_address_parser/v4/japanese_numeral'
 require 'japanese_address_parser/v4/data/prefecture_api'
 require 'japanese_address_parser/v4/data/machi_aza_api'
+require 'japanese_address_parser/v4/data/single_rsdt'
+require 'japanese_address_parser/v4/data/single_chiban'
 
 module JapaneseAddressParser
   module V4
@@ -210,14 +213,57 @@ module JapaneseAddressParser
         @cached_same_named_prefecture_city_regex_patterns = patterns
       end
 
-      # JS: getRsdt(pref, city, town, apiVersion) — M8 で実装する。
-      def get_rsdt(_pref, _city, _town, _api_version)
-        raise(::NotImplementedError, 'getRsdt is implemented in M8 (level 8)')
+      # JS: getRsdt(pref, city, town, apiVersion)
+      def get_rsdt(pref, city, town, api_version)
+        row = town.csv_ranges&.dig('住居表示')
+        return [] if row.nil?
+
+        fetch_from_cache("住居表示-#{pref.code}-#{city.code}-#{town.machi_aza_name}") do
+          rsdts = parse_subresource(fetch_subresource('住居表示', pref, city, row, api_version))
+          # JS: [blk_num, rsdt_num, rsdt_num2].filter(Boolean).join('-') の長さ降順（rsdt_to_string と同義）。
+          stable_sort_by(rsdts) { |rsdt| -rsdt.rsdt_to_string.length }
+        end
       end
 
-      # JS: getChiban(pref, city, town, apiVersion) — M8 で実装する。
-      def get_chiban(_pref, _city, _town, _api_version)
-        raise(::NotImplementedError, 'getChiban is implemented in M8 (level 8)')
+      # JS: getChiban(pref, city, town, apiVersion)
+      def get_chiban(pref, city, town, api_version)
+        row = town.csv_ranges&.dig('地番')
+        return [] if row.nil?
+
+        fetch_from_cache("地番-#{pref.code}-#{city.code}-#{town.machi_aza_name}") do
+          chibans = parse_subresource(fetch_subresource('地番', pref, city, row, api_version))
+          # JS: [prc_num1, prc_num2, prc_num3].filter(Boolean).join('-') の長さ降順（chiban_to_string と同義）。
+          stable_sort_by(chibans) { |chiban| -chiban.chiban_to_string.length }
+        end
+      end
+
+      # JS: fetchSubresource(kind, pref, city, row, apiVersion) — 住居表示/地番 .txt を Range 部分取得する。
+      def fetch_subresource(kind, pref, city, row, api_version)
+        # get_towns 同様、encodeURI せず生の県名・市名を渡す（Fetcher#http_request 側で一括エンコード）。
+        input = ['', pref.prefecture_name, "#{city.city_name}-#{kind}.txt?v=#{api_version}"].join('/')
+        Fetcher.fetch(input, offset: row['start'], length: row['length']).text
+      end
+
+      # JS: parseSubresource<T>(data) — 先頭1行を捨て、残りを header 付き CSV としてパースして VO 化する。
+      def parse_subresource(data)
+        # JS: firstLineEnd = data.indexOf('\n')（未検出は -1）; rest = data.slice(firstLineEnd + 1)
+        first_line_end = data.index("\n") || -1
+        rest = data[(first_line_end + 1)..].to_s
+        ::CSV.parse(rest, headers: true).filter_map do |row|
+          point = point_from(row['lng'], row['lat'])
+          if row.headers.include?('blk_num') # JS: 'blk_num' in line
+            Data::SingleRsdt.new(blk_num: row['blk_num'], rsdt_num: row['rsdt_num'], rsdt_num2: row['rsdt_num2'], point: point)
+          elsif row.headers.include?('prc_num1') # JS: 'prc_num1' in line
+            Data::SingleChiban.new(prc_num1: row['prc_num1'], prc_num2: row['prc_num2'], prc_num3: row['prc_num3'], point: point)
+          end
+        end
+      end
+
+      # JS: line.lng && line.lat ? [parseFloat(lng), parseFloat(lat)] : undefined（nil・空文字は falsy）。
+      def point_from(lng, lat)
+        return if lng.to_s.empty? || lat.to_s.empty?
+
+        [Float(lng), Float(lat)]
       end
 
       # --- 内部ヘルパ ---
@@ -286,7 +332,16 @@ module JapaneseAddressParser
         "(#{patterns.join('|')})((丁|町)目?|番(町|丁)|条|軒|線|の町?|地割|号|[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━])"
       end
 
-      private_class_method :cached_city_patterns, :cached_towns, :stable_sort_by, :town_sort_length, :kanji_number_followed_by_cho?, :town_pattern_source, :expand_town_number
+      private_class_method :cached_city_patterns,
+                           :cached_towns,
+                           :stable_sort_by,
+                           :town_sort_length,
+                           :kanji_number_followed_by_cho?,
+                           :town_pattern_source,
+                           :expand_town_number,
+                           :fetch_subresource,
+                           :parse_subresource,
+                           :point_from
     end
     public_constant :CacheRegexes
   end

--- a/sig/v4/cache_regexes.rbs
+++ b/sig/v4/cache_regexes.rbs
@@ -34,8 +34,11 @@ module JapaneseAddressParser
       def self.get_towns: (Data::SinglePrefecture pref_obj, Data::SingleCity city_obj, Integer api_version) -> Data::MachiAzaApi
       def self.get_town_regex_patterns: (Data::SinglePrefecture pref, Data::SingleCity city, Integer api_version) -> Array[[untyped, String]]
       def self.get_same_named_prefecture_city_regex_patterns: (Data::PrefectureApi pref_api) -> Array[[String, String]]
-      def self.get_rsdt: (untyped pref, untyped city, untyped town, untyped api_version) -> bot
-      def self.get_chiban: (untyped pref, untyped city, untyped town, untyped api_version) -> bot
+      def self.get_rsdt: (Data::SinglePrefecture pref, Data::SingleCity city, Data::SingleMachiAza town, Integer api_version) -> Array[Data::SingleRsdt]
+      def self.get_chiban: (Data::SinglePrefecture pref, Data::SingleCity city, Data::SingleMachiAza town, Integer api_version) -> Array[Data::SingleChiban]
+      def self.fetch_subresource: (String kind, Data::SinglePrefecture pref, Data::SingleCity city, Hash[String, Integer] row, Integer api_version) -> String
+      def self.parse_subresource: (String data) -> Array[untyped]
+      def self.point_from: (untyped lng, untyped lat) -> [Float, Float]?
 
       def self.cached_city_patterns: () -> Hash[Integer, Array[[Data::SingleCity, String]]]
       def self.cached_towns: () -> Hash[String, Data::MachiAzaApi]

--- a/spec/v4/cache_regexes_spec.rb
+++ b/spec/v4/cache_regexes_spec.rb
@@ -107,12 +107,5 @@ require 'japanese_address_parser/v4/cache_regexes'
     end
   end
 
-  describe '.get_rsdt / .get_chiban (M8 stubs)' do
-    it 'raises NotImplementedError until M8' do
-      expect { described_class.get_rsdt(nil, nil, nil, nil) }
-        .to(raise_error(::NotImplementedError))
-      expect { described_class.get_chiban(nil, nil, nil, nil) }
-        .to(raise_error(::NotImplementedError))
-    end
-  end
+  # get_rsdt / get_chiban の実装は spec/v4/cache_regexes_subresource_spec.rb に移した（M8）。
 end

--- a/spec/v4/cache_regexes_subresource_spec.rb
+++ b/spec/v4/cache_regexes_subresource_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# M8 の level 8 データアクセス（fetchSubresource / parseSubresource / getRsdt / getChiban）。
+# parse は .txt サンプルでオフライン検証、get_rsdt/get_chiban は上流同様ライブ CDN を Range 取得する。
+
+require 'japanese_address_parser/v4/cache_regexes'
+
+::RSpec.describe(::JapaneseAddressParser::V4::CacheRegexes) do
+  describe '.parse_subresource' do
+    it 'drops the first line, then builds SingleRsdt rows (header has blk_num)' do
+      data = <<~TXT
+        メタ行（先頭1行は捨てる）
+        blk_num,rsdt_num,rsdt_num2,lng,lat
+        10,8,,139.697,35.659
+        1,2,3,,
+      TXT
+
+      rsdts = described_class.__send__(:parse_subresource, data)
+
+      expect(rsdts.map(&:class).uniq).to(eq([::JapaneseAddressParser::V4::Data::SingleRsdt]))
+      # 空欄は Ruby の CSV では nil（JS の Papa.parse は '' ）。rsdt_to_string は両方を落とすので挙動は同値。
+      expect(rsdts[0]).to(have_attributes(blk_num: '10', rsdt_num: '8', rsdt_num2: nil, point: [139.697, 35.659]))
+      expect(rsdts[1]).to(have_attributes(rsdt_to_string: '1-2-3', point: nil))
+    end
+
+    it 'builds SingleChiban rows when the header has prc_num1' do
+      data = <<~TXT
+        メタ行
+        prc_num1,prc_num2,prc_num3,lng,lat
+        100,,,139.7,35.6
+      TXT
+
+      chibans = described_class.__send__(:parse_subresource, data)
+
+      expect(chibans[0]).to(have_attributes(prc_num1: '100', chiban_to_string: '100', point: [139.7, 35.6]))
+    end
+  end
+
+  describe '.get_rsdt', :upstream_port do
+    let(:api)         { described_class.get_prefectures                      }
+    let(:api_version) { api.meta.updated                                     }
+    let(:tokyo)       { api.data.find { |pref| pref.pref == '東京都' }          }
+    let(:shibuya)     { tokyo.cities.find { |city| city.city_name == '渋谷区' } }
+    let(:dogenzaka) do
+      described_class.get_towns(tokyo, shibuya, api_version).data.find { |town| town.machi_aza_name == '道玄坂一丁目' }
+    end
+
+    it 'range-fetches 住居表示 rows and includes 街区10-住居8 (道玄坂1-10-8)' do
+      rsdts = described_class.get_rsdt(tokyo, shibuya, dogenzaka, api_version)
+
+      expect(rsdts).to(all(be_a(::JapaneseAddressParser::V4::Data::SingleRsdt)))
+      expect(rsdts).to(include(have_attributes(blk_num: '10', rsdt_num: '8')))
+    end
+
+    it 'returns [] when the town has no 住居表示 range' do
+      no_rsdt_town = ::JapaneseAddressParser::V4::Data::SingleMachiAza.from_json('machiaza_id' => '0000000', 'oaza_cho' => 'x')
+
+      expect(described_class.get_rsdt(tokyo, shibuya, no_rsdt_town, api_version)).to(eq([]))
+    end
+  end
+end


### PR DESCRIPTION
## 概要

M8（level 8: rsdt/chiban）の **PR1**。`cacheRegexes.ts` の level 8 データアクセス（`getRsdt`/`getChiban`/`fetchSubresource`/`parseSubresource`）を移植する。normalize の level 8 分岐（pending 一括解除）は PR2。

## 変更点

- **`get_rsdt` / `get_chiban`**（`NotImplementedError` スタブ→本実装）: `town.csv_ranges` の `住居表示`/`地番` レンジが無ければ `[]`。あれば `fetch_from_cache` で fetch＋parse し、`rsdt_to_string`/`chiban_to_string` の**長さ降順**に安定ソート。
- **`fetch_subresource`**: `['', prefN, "#{cityN}-#{kind}.txt?v=#{apiVersion}"].join('/')` を `Fetcher.fetch(..., offset:, length:)` で **HTTP Range 部分取得**（`get_towns` 同様 encodeURI せず Fetcher 側でエンコード）。
- **`parse_subresource`**: 先頭1行を捨て（JS `indexOf('\n')+slice` に忠実。未検出 -1）、残りを header 付き CSV でパース。`blk_num` 列があれば `SingleRsdt`、`prc_num1` 列があれば `SingleChiban`。`lng`/`lat` から point 生成。
- RBS 追加。旧「M8 スタブ→NotImplementedError」テストを削除し、`cache_regexes_subresource_spec.rb` に実テストを新設。

## テスト

- `parse_subresource`: `.txt` サンプルでオフライン検証（先頭行除去・CSV・VO・point・空欄=nil の JS↔Ruby 差異を明記）。
- `get_rsdt`: ライブ CDN（`:upstream_port`）で `道玄坂一丁目` の `csv_ranges` から Range 取得し、`blk_num '10'/rsdt_num '8'`（＝道玄坂1-10-8）を含むことを検証。

## 検証

- `bundle exec rspec spec/v4/` … 7432 examples, 0 failures, 5653 pending（**pending は PR2 で解除**）
- `bundle exec rubocop`（v4/sig）… no offenses
- `bundle exec steep check` … No type error

base: \`rearchitecture\`