### PR TITLE
feat(v4): implement level-8 normalization and complete M8

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,16 +80,6 @@ RSpec/FilePath:
   Exclude:
     - spec/v4/**/*_spec.rb
 
-# v4 移植スイートでは level 8 が必要なケースを M8 まで pending で枠だけ確保する（M7 DoD）。
-# インライン disable は禁止（Style/DisableCopsWithinSourceCodeDirective）のため、pending を持つ
-# ファイルを個別に除外する。M8 で pending が外れたら該当エントリも削除する。
-RSpec/Pending:
-  Exclude:
-    - spec/v4/main_spec.rb
-    - spec/v4/addresses_spec.rb
-    - spec/v4/metadata_spec.rb
-    - spec/v4/filesystem_api_spec.rb
-
 # filesystem_api_spec は CDN から tmpdir へ一度だけ DL するため before/after(:context) を使う。
 # 状態（Config / モジュールキャッシュ）は around で example ごとに復元・reset し、tmpdir は
 # after(:context) で削除するので、本 cop が警告する状態リークは管理済み。

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -13,7 +13,7 @@
 - [x] **M5** normalize 本体（level 0–3）
 - [x] **M6** 公開 API & リッチ VO
 - [x] **M7** テストスイート移植
-- [ ] **M8** level 8（rsdt / chiban）
+- [x] **M8** level 8（rsdt / chiban）
 - [ ] **M9** 旧実装撤去 & 仕上げ
 - [ ] **M10** アップストリーム追従自動化 & リリース
 

--- a/lib/japanese_address_parser/v4/normalize.rb
+++ b/lib/japanese_address_parser/v4/normalize.rb
@@ -143,8 +143,42 @@ module JapaneseAddressParser
         level_value += 1 if town
 
         # JS: if (option.level <= 3 || level < 3) { return result }
-        # M8 で level 8（normalizeAddrPart）の分岐をここに追加する。M5 では常にこの結果を返す。
         # metadata は VO に昇格しない生データの逃がし道（working_agreement §1-3）。
+        if level <= 3 || level_value < 3
+          return NormalizeResult.new(
+            pref: pref ? pref.prefecture_name : nil,
+            city: city ? city.city_name : nil,
+            town: town ? town.machi_aza_name : nil,
+            addr: addr,
+            other: other,
+            point: point,
+            level: level_value,
+            metadata: NormalizeResultMetadata.new(
+              input: address,
+              prefecture: Utils.remove_cities_from_prefecture(pref),
+              city: city,
+              machi_aza: Utils.remove_extra_from_machi_aza(town),
+              chiban: nil,
+              rsdt: nil
+            )
+          )
+        end
+
+        # level 8（住居表示 rsdt / 地番 chiban）。ここに来るのは level_value == 3 かつ level >= 4 のとき。
+        normalized_addr_part = normalize_addr_part(other, pref, city, town, api_version)
+        # JS TODO: rsdt と地番を両方対応した時に両方返すけど、今は rsdt を優先する
+        if normalized_addr_part[:rsdt]
+          addr = normalized_addr_part[:rsdt].rsdt_to_string
+          other = normalized_addr_part[:rest]
+          point = ResultPoint.upgrade_point(point, ResultPoint.rsdt_or_chiban_to_result_point(normalized_addr_part[:rsdt]))
+          level_value = 8
+        elsif normalized_addr_part[:chiban]
+          addr = normalized_addr_part[:chiban].chiban_to_string
+          other = normalized_addr_part[:rest]
+          point = ResultPoint.upgrade_point(point, ResultPoint.rsdt_or_chiban_to_result_point(normalized_addr_part[:chiban]))
+          level_value = 8
+        end
+
         NormalizeResult.new(
           pref: pref ? pref.prefecture_name : nil,
           city: city ? city.city_name : nil,
@@ -158,8 +192,8 @@ module JapaneseAddressParser
             prefecture: Utils.remove_cities_from_prefecture(pref),
             city: city,
             machi_aza: Utils.remove_extra_from_machi_aza(town),
-            chiban: nil,
-            rsdt: nil
+            chiban: normalized_addr_part[:chiban],
+            rsdt: normalized_addr_part[:rsdt]
           )
         )
       end
@@ -201,7 +235,29 @@ module JapaneseAddressParser
           .strip
       end
 
-      private_class_method :normalize_town_name, :normalize_addr
+      # JS: normalizeAddrPart(addr, pref, city, town, apiVersion)
+      def normalize_addr_part(addr, pref, city, town, api_version)
+        # JS: /^([1-9][0-9]*)(?:-([1-9][0-9]*))?(?:-([1-9][0-9]*))?/（^ → \A）
+        match = addr.match(/\A([1-9][0-9]*)(?:-([1-9][0-9]*))?(?:-([1-9][0-9]*))?/)
+        return { rest: addr } unless match
+
+        matched = match[0].to_s
+        # JS TODO: rsdt の場合は rsdt と地番を両方取得する
+        if town.rsdt
+          CacheRegexes.get_rsdt(pref, city, town, api_version).each do |rsdt|
+            addr_part = rsdt.rsdt_to_string
+            return { rsdt: rsdt, rest: addr[addr_part.length..].to_s } if matched == addr_part
+          end
+        else
+          CacheRegexes.get_chiban(pref, city, town, api_version).each do |chiban|
+            addr_part = chiban.chiban_to_string
+            return { chiban: chiban, rest: addr[addr_part.length..].to_s } if matched == addr_part
+          end
+        end
+        { rest: addr }
+      end
+
+      private_class_method :normalize_town_name, :normalize_addr, :normalize_addr_part
     end
     public_constant :Normalize
   end

--- a/lib/japanese_address_parser/v4/normalize_result_point.rb
+++ b/lib/japanese_address_parser/v4/normalize_result_point.rb
@@ -53,6 +53,13 @@ module JapaneseAddressParser
         NormalizeResultPoint.new(lat: machi_aza.point[1], lng: machi_aza.point[0], level: 3)
       end
 
+      # JS: rsdtOrChibanToResultPoint(input) — input.point が無ければ undefined（rsdt/chiban 共通、level 8）。
+      def rsdt_or_chiban_to_result_point(input)
+        return if input.point.nil?
+
+        NormalizeResultPoint.new(lat: input.point[1], lng: input.point[0], level: 8)
+      end
+
       # JS: upgradePoint(a, b) — より正確（level の大きい）方を採用する
       def upgrade_point(point_a, point_b)
         return point_b if point_a.nil?

--- a/sig/v4/normalize.rbs
+++ b/sig/v4/normalize.rbs
@@ -13,6 +13,7 @@ module JapaneseAddressParser
       def self.call: (String address, ?level: Integer) -> NormalizeResult
       def self.normalize_town_name: (String input, Data::SinglePrefecture pref, Data::SingleCity city, Integer api_version) -> { town: untyped, other: String }?
       def self.normalize_addr: (String other) -> String
+      def self.normalize_addr_part: (String addr, untyped pref, untyped city, untyped town, Integer api_version) -> Hash[Symbol, untyped]
     end
   end
 end

--- a/sig/v4/normalize_result_point.rbs
+++ b/sig/v4/normalize_result_point.rbs
@@ -18,6 +18,7 @@ module JapaneseAddressParser
       def self.prefecture_to_result_point: (Data::SinglePrefecture pref) -> NormalizeResultPoint
       def self.city_to_result_point: (Data::SingleCity city) -> NormalizeResultPoint
       def self.machi_aza_to_result_point: (Data::SingleMachiAza machi_aza) -> NormalizeResultPoint?
+      def self.rsdt_or_chiban_to_result_point: (Data::SingleRsdt | Data::SingleChiban input) -> NormalizeResultPoint?
       def self.upgrade_point: (NormalizeResultPoint? point_a, NormalizeResultPoint? point_b) -> NormalizeResultPoint?
     end
   end

--- a/spec/v4/addresses_spec.rb
+++ b/spec/v4/addresses_spec.rb
@@ -4,8 +4,7 @@
 # 上流同様ライブ CDN を叩く（working_agreement §1-8、:upstream_port）。上流はリトライ/キャッシュ無し
 # （concurrency: 4 で直叩き）なので本移植も対策を入れず逐次でライブ CDN を叩く。
 #
-# 上流 normalize は level 8 を実装済みで全行 pass するが、本 gem は M8 未了のため level 8 行は pending。
-# M8 で `pending ... if expected_level == 8` の1行を外せば、JS と同様に全行 active で pass する。
+# level 0-3 も level 8（rsdt/chiban）も全行アクティブで、上流 normalize と同値になることを検証する。
 # （RSpec/Pending はインライン disable 不可のため .rubocop.yml でこのファイルを除外している。）
 
 require 'csv'
@@ -42,7 +41,6 @@ require_relative 'support/match_close_to'
     expected = { pref: presence.call(row[1]), city: presence.call(row[2]), town: presence.call(row[3]), addr: presence.call(row[4]), other: row[5].to_s, level: expected_level, point: point }.compact
 
     it test_name do
-      pending('level 8 (rsdt/chiban) — enabled in M8') if expected_level == 8
       expect(described_class.call(address)).to(match_close_to(**expected))
     end
   end

--- a/spec/v4/api_spec.rb
+++ b/spec/v4/api_spec.rb
@@ -31,8 +31,11 @@ require 'japanese_address_parser/v4'
       expect(result.level).to(eq(0))
     end
 
-    it 'defaults to level 8 (capped at level 3 until M8)' do
-      expect(described_class.call(address).level).to(eq(3))
+    it 'resolves to level 8 (rsdt) with the default level' do
+      result = described_class.call(address)
+
+      expect(result.level).to(eq(8))
+      expect(result.addr).to(eq('17-11'))
     end
   end
 

--- a/spec/v4/filesystem_api_spec.rb
+++ b/spec/v4/filesystem_api_spec.rb
@@ -18,8 +18,9 @@ require_relative 'support/match_close_to'
   # 意図的に用意しない＝未提供エリアの検証用）。データは不変なので example ごとに落とし直さない。
   before(:context) do
     tmpdir = ::Dir.mktmpdir('jap-addr-fs-')
-    ['.json', '/東京都/渋谷区.json'].each do |relative|
-      # Config base が file://#{tmpdir}/ja なので ja.json と ja/東京都/渋谷区.json が並ぶ。
+    # ja.json / 渋谷区.json（町字）に加え、level 8 の住居表示 .txt も落とす（上流 filesystem-api.test.ts と同じ）。
+    ['.json', '/東京都/渋谷区.json', '/東京都/渋谷区-住居表示.txt'].each do |relative|
+      # Config base が file://#{tmpdir}/ja なので ja.json と ja/東京都/... が並ぶ。
       path = "#{tmpdir}/ja#{relative}"
       ::FileUtils.mkdir_p(::File.dirname(path))
       ::File.write(path, ::JapaneseAddressParser::V4::Fetcher.fetch(relative).body)
@@ -56,8 +57,7 @@ require_relative 'support/match_close_to'
     end
   end
 
-  it 'resolves to level 8 (rsdt) through file:// — pending until M8' do
-    pending('level 8 (rsdt) — enabled in M8')
+  it 'resolves to level 8 (rsdt) through file://' do
     expect(described_class.call('渋谷区道玄坂1-10-8')).to(match_close_to(pref: '東京都', city: '渋谷区', town: '道玄坂一丁目', level: 8))
   end
 end

--- a/spec/v4/main_spec.rb
+++ b/spec/v4/main_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Port of test/main/main.test.ts (basic tests)。上流同様ライブ CDN を叩く（working_agreement §1-8）。
-# level 8 が必要なケースは M8 まで pending（DoD）。比較は assertMatchCloseTo 相当の match_close_to。
+# level 8（rsdt）ケースを含め全ケースを検証する。比較は assertMatchCloseTo 相当の match_close_to。
 
 require 'japanese_address_parser/v4'
 require_relative 'support/match_close_to'
@@ -45,13 +45,10 @@ require_relative 'support/match_close_to'
     expect(normalize.call('あいうえお')).to(match_close_to(other: 'あいうえお', level: 0))
   end
 
-  # level 8（rsdt）ケースは M8 まで pending で枠を確保する（M7 DoD）。M8 で外れたら RSpec が FIXED を報告する。
-  # （RSpec/Pending はインライン disable 不可のため .rubocop.yml でこのファイルを除外している。）
-  describe '東京都江東区豊洲一丁目2-27 のパターンテスト (level 8 — pending until M8)' do
+  describe '東京都江東区豊洲一丁目2-27 のパターンテスト (level 8)' do
     addresses = ['東京都江東区豊洲1丁目2-27', '東京都江東区豊洲 1丁目2-27', '東京都江東区豊洲 1-2-27', '東京都 江東区 豊洲 1-2-27', '東京都江東区豊洲 １ー２ー２７', '東京都江東区豊洲 一丁目2-27', '江東区豊洲 一丁目2-27']
     addresses.each do |address|
       it address do
-        pending('level 8 (rsdt) — enabled in M8')
         expect(normalize.call(address)).to(match_close_to(pref: '東京都', city: '江東区', town: '豊洲一丁目', addr: '2-27', level: 8, point: { lat: 35.661166758, lng: 139.793685144, level: 8 }))
       end
     end
@@ -75,13 +72,12 @@ require_relative 'support/match_close_to'
     end
   end
 
-  # 上流 main.test.ts の対になる level 8 パターン（豊洲と同じく M8 まで pending）。
-  # 上流の期待 point.level は 8 ではなく 2（rsdt 座標が無く市の代表点へフォールバックする上流クセ）をそのまま移植。
-  describe '石川県七尾市藤橋町亥45番地1 のパターンテスト (level 8 — pending until M8)' do
+  # 上流 main.test.ts の対になる level 8 パターン。上流の期待 point.level は 8 ではなく 2
+  # （rsdt 座標が無く市の代表点へフォールバックする上流クセ）をそのまま移植する。
+  describe '石川県七尾市藤橋町亥45番地1 のパターンテスト (level 8)' do
     addresses = ['石川県七尾市藤橋町亥45番地1', '石川県七尾市藤橋町亥四十五番地1', '石川県七尾市藤橋町 亥 四十五番地1', '石川県七尾市藤橋町 亥 45-1', '七尾市藤橋町 亥 45-1']
     addresses.each do |address|
       it address do
-        pending('level 8 (rsdt) — enabled in M8')
         expect(normalize.call(address)).to(match_close_to(pref: '石川県', city: '七尾市', town: '藤橋町亥', addr: '45-1', level: 8, point: { lat: 37.043108, lng: 136.967296, level: 2 }))
       end
     end

--- a/spec/v4/metadata_spec.rb
+++ b/spec/v4/metadata_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Port of test/main/metadata.test.ts。上流同様ライブ CDN を叩く（:upstream_port）。
-# prefecture/city/machi_aza は level 3 で揃うのでアクティブ。rsdt は level 8 のため M8 まで pending。
+# prefecture/city/machi_aza（level 3）に加え rsdt（level 8）も検証する。level:2 指定時は machi_aza 以降が未設定。
 
 require 'japanese_address_parser/v4'
 
@@ -34,8 +34,7 @@ require 'japanese_address_parser/v4'
       expect(metadata.chiban).to(be_nil)
     end
 
-    it 'exposes rsdt (level 8) — pending until M8' do
-      pending('level 8 (rsdt) — enabled in M8')
+    it 'exposes rsdt (level 8)' do
       expect(metadata.rsdt.blk_num).to(eq('10'))
       expect(metadata.rsdt.rsdt_num).to(eq('8'))
     end

--- a/spec/v4/normalize_spec.rb
+++ b/spec/v4/normalize_spec.rb
@@ -39,8 +39,11 @@ require 'japanese_address_parser/v4/normalize'
         expect(result.point.level).to(eq(3))
       end
 
-      it 'caps at level 3 with the default level (level 8 is M8)' do
-        expect(described_class.call(address).level).to(eq(3))
+      it 'resolves to level 8 (rsdt) with the default level' do
+        result = described_class.call(address)
+
+        expect(result.level).to(eq(8))
+        expect(result.addr).to(eq('17-11'))
       end
     end
 


### PR DESCRIPTION
## 概要

M8（level 8: rsdt/chiban）の **PR2**。`normalize.ts` の level≤3 早期 return 以降を移植し、level 8 を有効化して **M8 を完了**する。M7 で pending にしていた全ケース（addresses.csv の 5639 行を含む）がアクティブで green になる。

## 変更点（lib）

- **`Normalize.normalize_addr_part`**: 番地部分を `/\A([1-9][0-9]*)(?:-…)?(?:-…)?/`（`^`→`\A`）でマッチし、`town.rsdt` に応じて `get_rsdt`/`get_chiban` の結果を走査。`match[0] == rsdt_to_string/chiban_to_string` の一致で `{ rsdt/chiban, rest }` を返す（rsdt 優先の上流 TODO も踏襲）。
- **`Normalize.call` の level 8 分岐**: `level <= 3 || level_value < 3` で早期 return（現行の level≤3 結果）。以降は `normalize_addr_part` を呼び、rsdt/chiban 一致時に `addr`/`other`/`point`（level 8 に upgrade）/`level_value=8` を更新して結果と `metadata.rsdt`/`chiban` に反映（JS 同様、結果構築は2箇所）。
- **`ResultPoint.rsdt_or_chiban_to_result_point`**（types.ts 移植、level 8 座標）。RBS 追加。

## 変更点（spec/docs）

- **pending 一括解除**: `main_spec`（豊洲・七尾）/`addresses_spec`（level 8 行）/`metadata_spec`（rsdt）/`filesystem_api_spec`（level 8）。`filesystem_api_spec` は `渋谷区-住居表示.txt` も DL（上流 filesystem-api.test.ts と同じ）。
- 陳腐化した「level 3 に制限（M8 まで）」テスト2件（`api_spec`/`normalize_spec`）を level 8（addr `17-11`）検証に更新。
- `.rubocop.yml` の `RSpec/Pending` 除外を削除、`docs/milestones.md` の **M8 を `[x]`**。

## 検証（DoD）

- `渋谷区道玄坂1-10-8` → town `道玄坂一丁目`, addr `10-8`, **level 8**, rsdt `blk_num 10 / rsdt_num 8`（JS 同値）。
- **`bundle exec rspec spec/v4/` … 7432 examples, 0 failures, 0 pending**（addresses.csv の level 8 **5639 行が全て上流と同値**）。
- `bundle exec rubocop`（v4/sig）… no offenses ／ `bundle exec steep check` … No type error

> 注: level 8 のサブリソース Range 取得が加わるため CI の RSpec は所要 ~8–10 分に延びます。

base: \`rearchitecture\`