### PR TITLE
chore(v4): bump to 4.0.0 and add upstream-tracking workflow (M10 prep)

### DIFF
--- a/.github/workflows/upstream-check.yml
+++ b/.github/workflows/upstream-check.yml
@@ -1,0 +1,75 @@
+name: Upstream check
+
+# 上流 @geolonia/normalize-japanese-addresses の新バージョンを検知し、追従用の Issue を自動作成する。
+# 注: v3.1.3 は 2024/12 以降リリースが無く実質フリーズしているため、低頻度（週次）で十分。
+on:
+  schedule:
+    - cron: '0 0 * * 1' # 毎週月曜 00:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3'
+
+    - name: Resolve versions
+      id: versions
+      run: |
+        # upstream.rb は依存ゼロの定数のみなので、bundler なしで直接読む。
+        current="$(ruby -Ilib -rjapanese_address_parser/upstream -e 'print JapaneseAddressParser::UPSTREAM_VERSION')"
+        current_sha="$(ruby -Ilib -rjapanese_address_parser/upstream -e 'print JapaneseAddressParser::UPSTREAM_COMMIT_SHA')"
+        latest="$(npm view @geolonia/normalize-japanese-addresses version)"
+        {
+          echo "current=${current}"
+          echo "current_sha=${current_sha}"
+          echo "latest=${latest}"
+        } >> "$GITHUB_OUTPUT"
+        echo "current=${current} latest=${latest}"
+
+    - name: Open a follow-up issue when the upstream is ahead
+      if: steps.versions.outputs.current != steps.versions.outputs.latest
+      env:
+        GH_TOKEN: ${{ github.token }}
+        CURRENT: ${{ steps.versions.outputs.current }}
+        CURRENT_SHA: ${{ steps.versions.outputs.current_sha }}
+        LATEST: ${{ steps.versions.outputs.latest }}
+      run: |
+        title="Upstream update: normalize-japanese-addresses ${CURRENT} -> ${LATEST}"
+
+        # 同名の open issue が既にあれば作らない（週次実行の重複防止）。
+        existing="$(gh issue list --state open --search "${title} in:title" --json number --jq '.[0].number')"
+        if [ -n "${existing}" ]; then
+          echo "Issue already open: #${existing}"
+          exit 0
+        fi
+
+        body="$(cat <<EOF
+        上流 [@geolonia/normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses) の新バージョンが公開されました。
+
+        - 追従中: \`${CURRENT}\` (\`${CURRENT_SHA}\`)
+        - 最新: \`${LATEST}\`
+        - 変更点（compare / release）を確認: https://github.com/geolonia/normalize-japanese-addresses/releases
+
+        ## 翻訳チェックリスト
+
+        1. \`docs/upstream_mapping.md\` の対応表で、変更された JS ファイル → Ruby 移植先を逆引きする。
+        2. 変更ファイルごとに逐語移植（\`docs/working_agreement.md\` §3。正規表現は文字列レベルでコピー、\`^\`/\`\$\` は \`\\\\A\`/\`\\\\z\` に翻訳）。
+        3. \`lib/japanese_address_parser/upstream.rb\` の \`UPSTREAM_VERSION\` / \`UPSTREAM_COMMIT_SHA\` を更新する。
+        4. 各ファイル先頭の移植元 URL の sha を更新する。
+        5. \`bundle exec rspec\` / \`bundle exec rubocop\` / \`bundle exec steep check\` を green にする。
+
+        _このissueは \`.github/workflows/upstream-check.yml\` により自動作成されました。_
+        EOF
+        )"
+
+        gh issue create --title "${title}" --body "${body}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,30 @@ Change Log の形式は [Keep a Changelog](http://keepachangelog.com/) に従い
 
 ### Fixed
 
-- [#109](https://github.com/yamat47/japanese_address_parser/pull/109) READMEにDocker composeを利用した際の使い方を追記([@tossyi](https://github.com/tossyi))
-- [#108](https://github.com/yamat47/japanese_address_parser/pull/108) Add csv to gemspec for new Ruby versions ([@balvig](https://github.com/balvig))
-- [#110](https://github.com/yamat47/japanese_address_parser/pull/110) Update local dev environment and CI settings.([@yamat47](https://github.com/yamat47))
-
 ### Security
+
+## [4.0.0]
+
+Node.js / `schmooze` 依存を撤去し、[@geolonia/normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses) **v3.1.3** を Ruby に逐語移植した大規模リアーキテクチャです。**v3.x との後方互換はありません。**
+
+### Added
+
+- 公開 API が正規化レベル（0/1/2/3/8）を返すようになりました。`level: 8` で住居表示（rsdt）・地番（chiban）まで解決します（既定は `8`、呼び出しごとに `level:` 指定可）。
+- リッチな Value Object（`Address` / `Prefecture` / `City` / `Town`）。`code` / カナ / ローマ字 / 郡 / 政令区 / `machiaza_id` / `chome_n` / `point`（`lat`/`lng`/`level`）等を保持します。
+- `point`（緯度経度＋精度レベル）と `metadata`（VO に昇格しない生データの逃がし道）を出力します。
+- `file://`／ローカルパスのデータ源を第一級サポート（level 8 は Range 部分読み）。`JapaneseAddressParser.configure` で `japanese_addresses_api` / `cache_size` を設定できます。
+- `JapaneseAddressParser::UPSTREAM_VERSION` / `UPSTREAM_COMMIT_SHA` 定数。
+
+### Changed
+
+- 住所データを **gem に同梱せず、配信 API から実行時に取得**するようになりました（既定はリモート）。**Node.js は不要**です。
+- `call` は常に `Address` を返します（未マッチは `level 0` の `Address`）。`nil`／例外になるのは fetch 失敗時のみ（`call` は `nil`、`call!` は `NormalizeError`）。
+- **スレッドセーフではありません**（上流同様）。起動時のキャッシュ暖機を推奨します。
+- Ruby の必要バージョンを **>= 3.2.0** に更新しました。
+
+### Removed
+
+- Node.js / `schmooze` ブリッジ、同梱 CSV データ（1,943 ファイル）、旧 CSV ベースの Model と関連 API（`furigana` 等）を削除しました。
 
 ## [3.2.0]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    japanese_address_parser (3.2.0)
+    japanese_address_parser (4.0.0)
       csv
       lru_redux
 

--- a/lib/japanese_address_parser/version.rb
+++ b/lib/japanese_address_parser/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module JapaneseAddressParser
-  VERSION = '3.2.0'
+  VERSION = '4.0.0'
   public_constant :VERSION
 end


### PR DESCRIPTION
## 概要

M10（アップストリーム追従自動化 & リリース）の **準備 PR**。リリース操作（`rearchitecture → main` マージ・`v4.0.0` タグ・公開）は別途・手動で行うため、本 PR はその準備までを含む。

## 変更点

- **`version.rb` → `4.0.0`**（`Gemfile.lock` も追随）。
- **`CHANGELOG.md`**: `[4.0.0]` セクション追記（Node/schmooze 撤去、データ源リモート化、公開 API 刷新＝`Address` VO・level 0/1/2/3/8、後方互換なし、Ruby >= 3.2）。
- **`.github/workflows/upstream-check.yml`**: 週次 cron ＋ `workflow_dispatch`。`npm view @geolonia/normalize-japanese-addresses version` と `JapaneseAddressParser::UPSTREAM_VERSION` を比較し、差分があれば追従用 Issue（compare リンク・翻訳チェックリスト付き）を自動作成。同名 open issue があればスキップ。

## 検証

- upstream-check の比較ロジックをローカルで dry-run: `current=3.1.3` == `latest=3.1.3` → Issue 作成なし（上流は 2024/12 以降フリーズ、想定どおり）。定数は依存ゼロの `upstream.rb` から bundler 無しで読む。
- YAML 妥当・`gem build` は `japanese_address_parser-4.0.0.gem` を生成。
- `bundle exec rubocop` … no offenses ／ `bundle exec steep check` … No type error ／ 代表 spec green。

## 次

本 PR マージ後、`rearchitecture → main` のリリース PR を作成します（v4.0.0 の一括リリース）。main へのマージ・タグ・gem 公開は手動で実施してください。

base: \`rearchitecture\`