### PR TITLE
docs: README を読みやすく整理し、CHANGELOG を PR 参照に絞る

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,26 +20,9 @@ Change Log の形式は [Keep a Changelog](http://keepachangelog.com/) に従い
 
 ## [4.0.0]
 
-Node.js / `schmooze` 依存を撤去し、[@geolonia/normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses) **v3.1.3** を Ruby に逐語移植した大規模リアーキテクチャです。**v3.x との後方互換はありません。**
-
-### Added
-
-- 公開 API が正規化レベル（0/1/2/3/8）を返すようになりました。`level: 8` で住居表示（rsdt）・地番（chiban）まで解決します（既定は `8`、呼び出しごとに `level:` 指定可）。
-- リッチな Value Object（`Address` / `Prefecture` / `City` / `Town`）。`code` / カナ / ローマ字 / 郡 / 政令区 / `machiaza_id` / `chome_n` / `point`（`lat`/`lng`/`level`）等を保持します。
-- `point`（緯度経度＋精度レベル）と `metadata`（VO に昇格しない生データの逃がし道）を出力します。
-- `file://`／ローカルパスのデータ源を第一級サポート（level 8 は Range 部分読み）。`JapaneseAddressParser.configure` で `japanese_addresses_api` / `cache_size` を設定できます。
-- `JapaneseAddressParser::UPSTREAM_VERSION` / `UPSTREAM_COMMIT_SHA` 定数。
-
 ### Changed
 
-- 住所データを **gem に同梱せず、配信 API から実行時に取得**するようになりました（既定はリモート）。**Node.js は不要**です。
-- `call` は常に `Address` を返します（未マッチは `level 0` の `Address`）。`nil`／例外になるのは fetch 失敗時のみ（`call` は `nil`、`call!` は `NormalizeError`）。
-- **スレッドセーフではありません**（上流同様）。起動時のキャッシュ暖機を推奨します。
-- Ruby の必要バージョンを **>= 3.2.0** に更新しました。
-
-### Removed
-
-- Node.js / `schmooze` ブリッジ、同梱 CSV データ（1,943 ファイル）、旧 CSV ベースの Model と関連 API（`furigana` 等）を削除しました。
+- [#139](https://github.com/yamat47/japanese_address_parser/pull/139) Node.js への依存をなくし、@geolonia/normalize-japanese-addresses v3.1.3 と同じ仕組みで住所を正規化するように作り直しました（v3.x との後方互換はありません）([@yamat47](https://github.com/yamat47))
 
 ## [3.2.0]
 

--- a/README.md
+++ b/README.md
@@ -2,84 +2,96 @@
 
 # JapaneseAddressParser
 
-JapaneseAddressParser は日本の住所を正規化する Ruby gem です。
+JapaneseAddressParser は日本の住所を正規化する Ruby 用のライブラリです。「東京都渋谷区道玄坂1-10-8」のような住所の文字列を受け取り、都道府県・市区町村・町名・番地に分解します。
 
-[@geolonia/normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses)
-**v3.1.3** の忠実な Ruby 移植で、住所データは配信 API から実行時に取得します。**Node.js は不要**です。
+住所の正規化には geolonia の [normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses)（バージョン 3.1.3）と同じ仕組みを使っています。動作に Node.js は必要ありません。
 
 ## インストール
 
-`Gemfile` に追記して `bundle install`：
+Gemfile に次の行を追加して `bundle install` を実行してください。
 
 ```ruby
 gem 'japanese_address_parser'
 ```
 
-Ruby 3.2 以上が必要です。
+Ruby 3.2 以降が必要です。
 
 ## 使い方
 
-```ruby
-address = JapaneseAddressParser.call('渋谷区道玄坂1-10-8')
+`JapaneseAddressParser.call` に住所の文字列を渡すと、正規化した結果を返します。
 
+```ruby
+address = JapaneseAddressParser.call('東京都渋谷区道玄坂1-10-8')
+
+address.prefecture.name #=> "東京都"
+address.city.name       #=> "渋谷区"
+address.town.name       #=> "道玄坂一丁目"
+address.addr            #=> "10-8"
+address.other           #=> ""
+address.level           #=> 8
+```
+
+都道府県・市区町村・町名には、名前のほかに読みがな・ローマ字・行政コードなどの情報も含まれています。
+
+```ruby
 address.prefecture.name        #=> "東京都"
 address.prefecture.code        #=> 130001
 address.prefecture.name_kana   #=> "トウキョウト"
 address.prefecture.name_romaji #=> "Tokyo"
 
-address.city.name              #=> "渋谷区"
-address.town.name              #=> "道玄坂一丁目"
-address.town.chome             #=> "一丁目"
-address.town.chome_n           #=> 1
+address.town.chome   #=> "一丁目"
+address.town.chome_n #=> 1
 
-address.addr                   #=> "10-8"   # 住居表示 or 地番（level 8）
-address.other                  #=> ""       # 末尾の未正規化部
-address.level                  #=> 8        # 0/1/2/3/8
-address.point                  #=> #<... lat: 35.6568..., lng: 139.6987..., level: 8>
+address.point #=> 緯度・経度とその精度
+address.to_h  #=> 住所全体をハッシュに変換する
+```
 
-address.to_h                   # ネスト VO・座標も含めた Hash
-address.metadata               # VO に昇格しない生データ（rsdt/chiban 等）の逃がし道
+### 正規化のレベル
+
+住所をどこまで判別できたかは `level` で表されます。
+
+- 0: 都道府県も判別できなかった
+- 1: 都道府県まで判別できた
+- 2: 市区町村まで判別できた
+- 3: 町名まで判別できた
+- 8: 住居表示または地番まで判別できた
+
+どのレベルまで判別するかは呼び出しごとに指定できます。指定しない場合は 8 まで判別します。
+
+```ruby
+JapaneseAddressParser.call('神奈川県横浜市港北区', level: 2).level #=> 2
 ```
 
 ### 戻り値と例外
 
-- `call` / `call!` は**常に `Address` を返します**。都道府県すら判別できなくても `level 0` の `Address` を返します（未マッチは失敗ではありません）。
-- `nil`／例外になるのは**データ取得（fetch）失敗時のみ**です。`call` は `nil` を返し、`call!` は `JapaneseAddressParser::NormalizeError` を raise します。
-- 正規化レベルは毎回 `level:` で指定できます（既定は `8`）。
+`call` は常に住所を返します。都道府県すら判別できなかった場合でも、`level` が 0 の住所を返します。住所として認識できないこと自体はエラーではありません。
+
+住所データの取得に失敗したときだけ、戻り値が変わります。`call` は `nil` を返し、`call!` は `JapaneseAddressParser::NormalizeError` を発生させます。
 
 ```ruby
-JapaneseAddressParser.call('神奈川県横浜市港北区', level: 2).level #=> 2
-JapaneseAddressParser.call!('渋谷区道玄坂1-10-8')                   # fetch 失敗時は NormalizeError
+JapaneseAddressParser.call('あいうえお').level #=> 0
+JapaneseAddressParser.call!('東京都渋谷区道玄坂1-10-8') # 取得に失敗すると例外
 ```
 
 ## 設定
 
+`JapaneseAddressParser.configure` で動作を設定できます。
+
 ```ruby
-JapaneseAddressParser.configure do |c|
-  # データ源。既定はリモート API。
-  c.japanese_addresses_api = 'https://japanese-addresses-v2.geoloniamaps.com/api/ja'
-  # 町字パターンの LRU キャッシュサイズ（既定 1000）。
-  c.cache_size = 1_000
+JapaneseAddressParser.configure do |config|
+  config.japanese_addresses_api = 'https://japanese-addresses-v2.geoloniamaps.com/api/ja'
+  config.cache_size = 1000
 end
 ```
 
-- `http://` / `https://` で始まる → HTTP で取得（level 8 は Range 部分取得）。
-- `file://` で始まる、または絶対/相対パス → ローカルファイルから取得（ミラーを置いて利用できます）。
-- 住所データは gem に**同梱していません**（level 3 で約 100MB、level 8 で数 GB のため）。
+設定できる項目は次の3つです。
 
-## スレッド安全性
+`japanese_addresses_api` は住所データの取得先です。指定しない場合は geolonia の配信 API を参照します。`http://` や `https://` で始まる値を指定するとネットワーク越しに取得し、`file://` で始まる値やローカルのパスを指定すると手元のファイルから読み込みます。住所データを手元に用意しておき、そちらを参照させることもできます。
 
-本 gem は**スレッドセーフではありません**（上流 JS と同じくモジュールレベルのキャッシュを使います）。
-マルチスレッドで使う場合は、**起動時に代表的な住所を1回正規化してキャッシュを暖機**しておくことを推奨します。
+`cache_size` は、町名の照合に使う正規表現をいくつ覚えておくかの上限です。指定しない場合は 1000 です。
 
-## 移植元（アップストリーム）
+`geolonia_api_key` は geolonia の API キーです。指定すると、住所データを取得するときのリクエストにこのキーを付けて送ります。
 
-```ruby
-JapaneseAddressParser::UPSTREAM_VERSION    #=> "3.1.3"
-JapaneseAddressParser::UPSTREAM_COMMIT_SHA #=> "49c1ae4be9d2ba353b86eaf40fd7eb12a1269f3e"
-```
+## スレッドセーフではありません
 
-## v4.0.0 について
-
-v4.0.0 で Node.js / `schmooze` 依存を撤去し、上流 v3.1.3 を Ruby に逐語移植しました。
-公開 API・戻り値の形は v3.x から変わっています（後方互換はありません）。
+このライブラリは、一度取得した住所データを内部で共有して使い回します。そのためスレッドセーフではありません。複数のスレッドから使う場合は、先に一度どこかで住所を正規化して内部のデータを読み込ませてから使うことをおすすめします。


### PR DESCRIPTION
## 概要

4.0.0 リリースに向けて、README と CHANGELOG を読み手にとって分かりやすい形に整えます。ドキュメントのみの変更です。

## README

初めて読む人に必要な情報だけを、自然な日本語で書き直しました。

- 設定項目（`japanese_addresses_api` / `cache_size` / `geolonia_api_key`）を、コードのコメントではなく地の文でそれぞれ説明しました。
- 分かりにくい言い回しや Markdown の太字（`**`）をやめました。
- 住所データを gem に同梱していない件や、v4.0.0 の位置づけの節など、初めて読む人には不要な記述を削りました。

掲載しているコード例は、いずれも実際に動作することを確認済みです（`configure` / `call` / `call!`、`prefecture.code`・`town.chome_n`・`point`・`to_h`、未判別時の `level` 0）。

## CHANGELOG

4.0.0 の項目を、変更内容を書き連ねる形から、リリース PR（#139）への参照ひとつに絞りました。何をどう変えたかの説明は PR 側に持たせる方針です。

補足: 4.0.0 は作り直しのため、リリース前に `[Unreleased]` に残っていた項目（#108 / #109 / #110）は今回のリリースに含まれるものとして 4.0.0 の参照にまとめ、個別の記載は省いています。復活させたい項目があれば教えてください。

base: `rearchitecture`